### PR TITLE
Release 1.0.0

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,7 @@
+# TODO: Remove this line once `@metamask/eslint-config` is updated. Yarn's
+# hardened mode currently causes issues with the patches in this repository.
+enableHardenedMode: false
+
 enableScripts: false
 
 logFilters:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/root",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "The root package of the monorepo.",
   "homepage": "https://github.com/ts-bridge/ts-bridge#readme",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0]
+
 ### Uncategorized
 
 - Initial commit
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.1.0...HEAD
+[0.1.0]: https://github.com/ts-bridge/ts-bridge/releases/tag/@ts-bridge/cli@0.1.0

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0]
 
-### Uncategorized
+### Added
 
-- Initial commit
+- Initial release of the `@ts-bridge/cli` package.
 
 [Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.1.0...HEAD
 [0.1.0]: https://github.com/ts-bridge/ts-bridge/releases/tag/@ts-bridge/cli@0.1.0

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Initial commit
+
 [Unreleased]: https://github.com/ts-bridge/ts-bridge/

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/cli",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Bridge the gap between ES modules and CommonJS modules with an easy-to-use alternative to `tsc`.",
   "keywords": [
     "build-tool",

--- a/packages/shims/CHANGELOG.md
+++ b/packages/shims/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0]
 
-### Uncategorized
+### Added
 
-- Initial commit
+- Initial release of the `@ts-bridge/shims` package.
 
 [Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/shims@0.1.0...HEAD
 [0.1.0]: https://github.com/ts-bridge/ts-bridge/releases/tag/@ts-bridge/shims@0.1.0

--- a/packages/shims/CHANGELOG.md
+++ b/packages/shims/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Initial commit
+
 [Unreleased]: https://github.com/ts-bridge/ts-bridge/

--- a/packages/shims/CHANGELOG.md
+++ b/packages/shims/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0]
+
 ### Uncategorized
 
 - Initial commit
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/shims@0.1.0...HEAD
+[0.1.0]: https://github.com/ts-bridge/ts-bridge/releases/tag/@ts-bridge/shims@0.1.0

--- a/packages/shims/package.json
+++ b/packages/shims/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/shims",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "CommonJS and ES Modules shims for TS Bridge.",
   "keywords": [
     "build-tool",


### PR DESCRIPTION
This is the release candidate for `1.0.0`. It bumps:

- `@ts-bridge/cli` to `0.1.0`.
- `@ts-bridge/shims` to `0.1.0`.