### PR TITLE
Bump several GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.23
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/c6bd06256dd700a45e483869bcdcf304239393a6/scripts/download-actionlint.bash) 1.6.27
         shell: bash
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color
@@ -60,7 +60,7 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     steps:
       - id: is-release
-        uses: MetaMask/action-is-release@dc4672b05e3b1d464cdaf783579b04a4e43f8b02
+        uses: MetaMask/action-is-release@v2
         with:
           commit-starts-with: 'Release [version],Release/[version]'
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -20,7 +20,7 @@ jobs:
   publish-docs:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.url }}
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -59,8 +59,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Dry run publish
         # Omit npm-token token to perform a dry run.
-        # TODO: Replace commit hash with latest release when published.
-        uses: MetaMask/action-npm-publish@70653d97d9bc2032176949a7bd2be46dace9d779
+        uses: MetaMask/action-npm-publish@v5
         env:
           SKIP_PREPACK: true
 
@@ -83,8 +82,7 @@ jobs:
           key: ${{ github.sha }}
           fail-on-cache-miss: true
       - name: Publish
-        # TODO: Replace commit hash with latest release when published.
-        uses: MetaMask/action-npm-publish@70653d97d9bc2032176949a7bd2be46dace9d779
+        uses: MetaMask/action-npm-publish@v5
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
         env:


### PR DESCRIPTION
This bumps `MetaMask/action-is-release` and `MetaMask/action-npm-publish` from an older commit hash to the latest release version, and `actionlint` to `1.6.27`.