### PR TITLE
Fix compatibility with TypeScript 4.x

### DIFF
--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -216,7 +216,10 @@ export function buildNode10({
           compilerOptions: {
             ...compilerOptions,
             module: typescript.ModuleKind.ES2022,
-            moduleResolution: ModuleResolutionKind.Node10,
+
+            // `ModuleResolutionKind.NodeJs` is in TypeScript 5 and later, but
+            // TypeScript 4 doesn't support `ModuleResolutionKind.Node10`.
+            moduleResolution: ModuleResolutionKind.NodeJs,
           },
           files,
           oldProgram: program,
@@ -240,7 +243,10 @@ export function buildNode10({
           compilerOptions: {
             ...compilerOptions,
             module: typescript.ModuleKind.CommonJS,
-            moduleResolution: ModuleResolutionKind.Node10,
+
+            // `ModuleResolutionKind.NodeJs` is in TypeScript 5 and later, but
+            // TypeScript 4 doesn't support `ModuleResolutionKind.Node10`.
+            moduleResolution: ModuleResolutionKind.NodeJs,
           },
           files,
           oldProgram: program,

--- a/packages/cli/src/transformers.ts
+++ b/packages/cli/src/transformers.ts
@@ -500,8 +500,14 @@ export function getNamedImportTransformer({
 }: TransformerOptions) {
   return (context: TransformationContext): Transformer<SourceFile> => {
     return (sourceFile: SourceFile) => {
-      const visitor = (node: Node): Node | Node[] => {
-        if (isImportDeclaration(node) && !node.importClause?.isTypeOnly) {
+      const visitor = (node: Node): Node | Node[] | undefined => {
+        if (isImportDeclaration(node)) {
+          if (node.importClause?.isTypeOnly) {
+            // If the import is type-only, we need to return `undefined` to
+            // avoid TypeScript 4.x from including the import in the output.
+            return undefined;
+          }
+
           return getNamedImportNodes(
             typeChecker,
             sourceFile,


### PR DESCRIPTION
This fixes some incompatibility issues with TypeScript 4.x:

- `ModuleResolutionKind.NodeJs` is deprecated, but TypeScript 4.x doesn't have the replacement `ModuleResolutionKind.Node10`, so it would set `moduleResolution` to `undefined`, resulting in build errors. I've fixed it by using the deprecated enum value, but we can replace it with `Node10` when (if?) we drop support for TypeScript 4.x.
- When visiting a type import in TypeScript 4.x, TypeScript doesn't remove the import from the output, so we have to return `undefined`.