### PR TITLE
Release 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/root",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "The root package of the monorepo.",
   "homepage": "https://github.com/ts-bridge/ts-bridge#readme",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Fix compatibility with TypeScript 4.x ([#6](https://github.com/ts-bridge/ts-bridge/pull/6))
+- Add MIT license ([#2](https://github.com/ts-bridge/ts-bridge/pull/2))
+
 ## [0.1.0]
 
 ### Added

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1]
+
 ### Uncategorized
 
 - Fix compatibility with TypeScript 4.x ([#6](https://github.com/ts-bridge/ts-bridge/pull/6))
@@ -18,5 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/cli` package.
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.1.0...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.1.1...HEAD
+[0.1.1]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.1.0...@ts-bridge/cli@0.1.1
 [0.1.0]: https://github.com/ts-bridge/ts-bridge/releases/tag/@ts-bridge/cli@0.1.0

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Bridge the gap between ES modules and CommonJS modules with an easy-to-use alternative to `tsc`.",
   "keywords": [
     "build-tool",

--- a/packages/shims/CHANGELOG.md
+++ b/packages/shims/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Add MIT license ([#2](https://github.com/ts-bridge/ts-bridge/pull/2))
+
 ## [0.1.0]
 
 ### Added

--- a/packages/shims/CHANGELOG.md
+++ b/packages/shims/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1]
+
 ### Uncategorized
 
 - Add MIT license ([#2](https://github.com/ts-bridge/ts-bridge/pull/2))
@@ -17,5 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/shims` package.
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/shims@0.1.0...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/shims@0.1.1...HEAD
+[0.1.1]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/shims@0.1.0...@ts-bridge/shims@0.1.1
 [0.1.0]: https://github.com/ts-bridge/ts-bridge/releases/tag/@ts-bridge/shims@0.1.0

--- a/packages/shims/package.json
+++ b/packages/shims/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/shims",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CommonJS and ES Modules shims for TS Bridge.",
   "keywords": [
     "build-tool",


### PR DESCRIPTION
This is the release candidate for `2.0.0`. It bumps `@ts-bridge/cli` and `@ts-bridge/shims` to `v0.1.1` to add a LICENSE file and fix a TypeScript 4.x compatibility issue.