### PR TITLE
Add transformer to remove type imports and exports

### DIFF
--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -23,6 +23,7 @@ import type { Steps } from './steps.js';
 import { executeSteps } from './steps.js';
 import type { TransformerOptions } from './transformers.js';
 import {
+  getTypeImportExportTransformer,
   getExportExtensionTransformer,
   getImportExtensionTransformer,
   getRequireExtensionTransformer,
@@ -379,6 +380,7 @@ export function build({
         getRequireExtensionTransformer(extension, options),
         getImportExtensionTransformer(extension, options),
         getExportExtensionTransformer(extension, options),
+        getTypeImportExportTransformer(options),
         ...getTransformers(type, options),
       ],
       afterDeclarations: [


### PR DESCRIPTION
When using TypeScript 4.8, type imports and exports weren't removed from the output, resulting in invalid output. I'm not sure if this is a bug in the compiler API, or if it's intended behaviour, as it works fine without the transformer in TypeScript 5.4. Either way, we can just add a transformer that removes the type imports and exports.