### PR TITLE
Run tests on all supported TypeScript versions

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -5,6 +5,7 @@
     "@metamask/auto-changelog",
     "@metamask/create-release-branch",
     "@vitest/coverage-istanbul",
+    "semver",
     "prettier-plugin-packagejson"
   ]
 }

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -116,7 +116,8 @@ jobs:
       - name: Install Yarn dependencies
         run: yarn --immutable --immutable-cache
       - name: Get supported TypeScript versions
-        run: echo "typescript-versions=$(yarn get-supported-typescript-versions)" >> $GITHUB_OUTPUT
+        id: get-supported-versions
+        run: echo "typescript-versions=$(yarn get-typescript-versions)" >> "$GITHUB_OUTPUT"
 
   compatibility-test:
     name: Compatibility Test

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -120,7 +120,7 @@ jobs:
         run: echo "typescript-versions=$(yarn get-typescript-versions)" >> "$GITHUB_OUTPUT"
 
   compatibility-test:
-    name: Compatibility Test
+    name: Compatibility test
     runs-on: ubuntu-latest
     needs:
       - get-supported-versions

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -97,3 +97,56 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
+
+  get-supported-versions:
+    name: Get supported TypeScript versions
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+    outputs:
+      typescript-versions: ${{ steps.get-supported-versions.outputs.typescript-versions }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: Install Yarn dependencies
+        run: yarn --immutable --immutable-cache
+      - name: Get supported TypeScript versions
+        run: echo "typescript-versions=$(yarn get-supported-typescript-versions)" >> $GITHUB_OUTPUT
+
+  compatibility-test:
+    name: Compatibility Test
+    runs-on: ubuntu-latest
+    needs:
+      - get-supported-versions
+    strategy:
+      max-parallel: 2
+      matrix:
+        typescript-version: ${{ fromJson(needs.get-supported-versions.outputs.typescript-versions) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: Install Yarn dependencies
+        run: yarn --immutable --immutable-cache
+      - name: Build `@ts-bridge/shims`
+        run: yarn workspace @ts-bridge/shims build
+      - name: Install TypeScript ${{ matrix.typescript-version }}
+        run: yarn workspaces foreach -A add -D typescript@${{ matrix.typescript-version }}
+      - name: Test
+        run: yarn test
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -125,7 +125,6 @@ jobs:
     needs:
       - get-supported-versions
     strategy:
-      max-parallel: 2
       matrix:
         typescript-version: ${{ fromJson(needs.get-supported-versions.outputs.typescript-versions) }}
     steps:
@@ -143,11 +142,4 @@ jobs:
       - name: Install TypeScript ${{ matrix.typescript-version }}
         run: yarn workspaces foreach -A add -D typescript@${{ matrix.typescript-version }}
       - name: Test
-        run: yarn test
-      - name: Require clean working directory
-        shell: bash
-        run: |
-          if ! git diff --exit-code; then
-            echo "Working tree dirty at end of job"
-            exit 1
-          fi
+        run: yarn test --coverage false

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "tsc --build ./tsconfig.build.json",
     "build:docs": "retype build",
+    "get-typescript-versions": "./scripts/get-typescript-versions.sh",
     "postinstall": "simple-git-hooks",
     "lint": "yarn lint:eslint && yarn lint:constraints && yarn lint:misc --check && yarn lint:dependencies --check && yarn lint:changelogs",
     "lint:changelogs": "yarn workspaces foreach --all --no-private run lint:changelog",
@@ -66,6 +67,7 @@
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.0",
     "retypeapp": "^3.5.0",
+    "semver": "^7.6.0",
     "simple-git-hooks": "^2.11.1",
     "typescript": "^5.4.5",
     "vite-tsconfig-paths": "^4.3.2",

--- a/packages/cli/src/build.test.ts
+++ b/packages/cli/src/build.test.ts
@@ -809,7 +809,7 @@ describe('build', () => {
       tsconfig: getMockTsConfig({
         compilerOptions: {
           module: 'ES2022',
-          moduleResolution: 'Node10',
+          moduleResolution: 'Node',
         },
       }),
     });
@@ -834,7 +834,7 @@ describe('build', () => {
       tsconfig: getMockTsConfig({
         compilerOptions: {
           module: 'ES2022',
-          moduleResolution: 'Node10',
+          moduleResolution: 'Node',
         },
       }),
     });

--- a/scripts/get-typescript-versions.sh
+++ b/scripts/get-typescript-versions.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Get the TypeScript version range from package.json
+version_range=$(jq --raw-output '.peerDependencies.typescript' packages/cli/package.json)
+
+# Fetch all versions and filter based on semver range.
+all_versions=$(npm show typescript time --json | jq --raw-output 'del(.modified, .created) | keys | .[] | @sh')
+declare -a all_versions_array="($all_versions)"
+versions=$(yarn semver "${all_versions_array[@]}" --range "$version_range" --loose | xargs)
+
+# Sort versions, extract `major.minor`, sort by `major.minor` and patch, get the
+# latest for each `major.minor`
+latest_patch_versions=$(echo "$versions" | tr ' ' '\n' | sort -V | awk -F. '{print $1"."$2"."$3}' | sort -t. -k1,1n -k2,2n -k3,3nr | awk -F. '!seen[$1"."$2]++')
+
+# Convert the versions to JSON.
+versions_json=$(echo "$latest_patch_versions" | jq --raw-input --raw-output --slurp 'split("\n") | .[0:-1]')
+
+# Output the JSON.
+echo "$versions_json"

--- a/scripts/get-typescript-versions.sh
+++ b/scripts/get-typescript-versions.sh
@@ -17,7 +17,7 @@ versions=$(yarn semver "${all_versions_array[@]}" --range "$version_range" --loo
 latest_patch_versions=$(echo "$versions" | tr ' ' '\n' | sort -V | awk -F. '{print $1"."$2"."$3}' | sort -t. -k1,1n -k2,2n -k3,3nr | awk -F. '!seen[$1"."$2]++')
 
 # Convert the versions to JSON.
-versions_json=$(echo "$latest_patch_versions" | jq --raw-input --raw-output --slurp 'split("\n") | .[0:-1]')
+versions_json=$(echo "$latest_patch_versions" | jq --raw-input --raw-output --compact-output --slurp 'split("\n") | .[0:-1]')
 
 # Output the JSON.
 echo "$versions_json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,6 +1131,7 @@ __metadata:
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.0"
     retypeapp: "npm:^3.5.0"
+    semver: "npm:^7.6.0"
     simple-git-hooks: "npm:^2.11.1"
     typescript: "npm:^5.4.5"
     vite-tsconfig-paths: "npm:^4.3.2"


### PR DESCRIPTION
This adds a step in CI to run tests on all supported TypeScript versions. This will ensure compatibility of TS Bridge with these versions.

Blocked by:
- #10
- #12

Closes #7.