### PR TITLE
Bump minimum TypeScript version to 4.8

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,7 +8,7 @@ icon: download
 ## Requirements
 
 - Node.js 18.18 or later.
-- TypeScript 4.0 or later.
+- TypeScript 4.8 or later.
 
 ## Installing the CLI
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "vitest": "^1.5.0"
   },
   "peerDependencies": {
-    "typescript": ">=4.0.0"
+    "typescript": ">=4.8.0"
   },
   "packageManager": "yarn@4.1.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -71,9 +71,6 @@
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.0"
   },
-  "peerDependencies": {
-    "typescript": ">=4.8.0"
-  },
   "packageManager": "yarn@4.1.1",
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "@ts-bridge/shims": "workspace:^",
-    "typescript": ">=4.0.0"
+    "typescript": ">=4.8.0"
   },
   "peerDependenciesMeta": {
     "@ts-bridge/shims": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,8 +1135,6 @@ __metadata:
     typescript: "npm:^5.4.5"
     vite-tsconfig-paths: "npm:^4.3.2"
     vitest: "npm:^1.5.0"
-  peerDependencies:
-    typescript: ">=4.0.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,7 +1095,7 @@ __metadata:
     yargs: "npm:^17.7.2"
   peerDependencies:
     "@ts-bridge/shims": "workspace:^"
-    typescript: ">=4.0.0"
+    typescript: ">=4.8.0"
   peerDependenciesMeta:
     "@ts-bridge/shims":
       optional: true


### PR DESCRIPTION
Looks like `>=4.0.0` was a bit too optimistic. I've bumped the minimum required version to 4.8 because supporting older versions seems quite complicated.