### PR TITLE
Fix "ENOENT: no such file or directory, mkdir '...'" error when using nested folders

### DIFF
--- a/packages/cli/src/file-system.ts
+++ b/packages/cli/src/file-system.ts
@@ -1,5 +1,5 @@
 import { rmSync } from 'fs';
-import { dirname, sep, resolve, normalize } from 'path';
+import { sep, resolve, normalize } from 'path';
 import type { System, WriteFileCallback } from 'typescript';
 import typescript from 'typescript';
 
@@ -80,17 +80,12 @@ export function getWriteFileFunction(
       declarationExtension,
     );
 
-    const directoryName = dirname(fileNameWithExtension);
     const updatedContent = transformFile(
       fileName,
       content,
       extension,
       declarationExtension,
     );
-
-    if (!system.directoryExists(directoryName)) {
-      system.createDirectory(directoryName);
-    }
 
     system.writeFile(fileNameWithExtension, updatedContent, writeByteOrderMark);
   };


### PR DESCRIPTION
When using nested folders, i.e., `src/folder/nested-folder`, TypeScript may compile files in `nested-folder` before `folder`. We then call `system.createDirectory`, but since this function does create parent directories, it results in:

> ENOENT: no such file or directory, mkdir './src/folder/nested-folder'

It turns out calling `system.createDirectory` is redundant anyway, as `system.writeFile` will handle this under the hood, so I've simply removed it.