### PR TITLE
Check parent paths for `package.json` file when checking if a module is ESM

### DIFF
--- a/packages/cli/src/module-resolver.test.ts
+++ b/packages/cli/src/module-resolver.test.ts
@@ -12,6 +12,7 @@ import {
   getPackageEntryPoint,
   getPackageJson,
   getPackageName,
+  getPackageParentPaths,
   getPackagePath,
   isESModule,
 } from './module-resolver.js';
@@ -46,6 +47,30 @@ describe('getPackageName', () => {
     expect(() => getPackageName('')).toThrowError(
       'Invalid package specifier: "".',
     );
+  });
+});
+
+describe('getPackageParentPaths', () => {
+  it('returns the paths of the parent directories of a package', () => {
+    const paths = getPackageParentPaths(
+      'typescript/foo/bar/baz',
+      BASE_DIRECTORY,
+    );
+
+    expect(paths[0]).toBe(resolve(BASE_DIRECTORY, 'typescript/foo/bar'));
+    expect(paths[1]).toBe(resolve(BASE_DIRECTORY, 'typescript/foo'));
+    expect(paths).not.toContain(resolve(BASE_DIRECTORY, 'typescript'));
+  });
+
+  it('returns the paths of the parent directories of a scoped package', () => {
+    const paths = getPackageParentPaths(
+      '@babel/core/foo/bar/baz',
+      BASE_DIRECTORY,
+    );
+
+    expect(paths[0]).toBe(resolve(BASE_DIRECTORY, '@babel/core/foo/bar'));
+    expect(paths[1]).toBe(resolve(BASE_DIRECTORY, '@babel/core/foo'));
+    expect(paths).not.toContain(resolve(BASE_DIRECTORY, '@babel/core'));
   });
 });
 


### PR DESCRIPTION
This updates the `package.json` resolution algorithm to check for parent paths of a given package specifier. For example, if we try to resolve the closest `package.json` to `my-module/foo/bar/index.js`, previously we would only check `my-module/foo/bar`. After this change, we also check `my-module/foo`, in order from deep to shallow.