### PR TITLE
Add `@ts-bridge/resolver` package

### DIFF
--- a/packages/resolver/.eslintrc.cjs
+++ b/packages/resolver/.eslintrc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+
+  env: {
+    browser: true,
+    node: true,
+  },
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+
+  overrides: [
+    {
+      files: ['*.ts'],
+      rules: {
+        'no-restricted-globals': 'off',
+      },
+    },
+  ],
+};

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/

--- a/packages/resolver/LICENSE
+++ b/packages/resolver/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Maarten Zuidhoorn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/resolver/README.md
+++ b/packages/resolver/README.md
@@ -1,0 +1,60 @@
+# `@ts-bridge/resolver`
+
+An implementation of the Node.js module resolution algorithm as defined in the
+specification [here](https://nodejs.org/api/esm.html#resolution-algorithm).
+
+## Why?
+
+There are several tools out there for resolving modules, such as
+[`enhanced-resolve`](https://github.com/webpack/enhanced-resolve), or
+[`import-meta-resolve`](https://github.com/wooorm/import-meta-resolve), or even
+Node.js' own `require.resolve` or `import.meta.resolve` functions. Unfortunately
+we cannot use these in TS Bridge, since the resolution logic has some specific
+requirements:
+
+- TS Bridge needs to know the format of a resolved module, i.e., whether it is
+  a CommonJS module, ES module, or something else.
+  - This is not trivial as Node.js has a lot of edge cases when determining the
+    format. Take a look at the `ESM_FILE_FORMAT` function in the
+    [specification](https://nodejs.org/api/esm.html#resolution-algorithm) if
+    you're curious.
+- TypeScript's compiler API is completely synchronous, so the module resolution
+  needs to be synchronous as well.
+
+To ensure correct behaviour, the best solution seemed to reimplement the
+algorithm as used by Node.js.
+
+## Usage
+
+> [!NOTE]
+> Usage outside of TS Bridge is possible, but not recommended. Consider using
+> a library like
+> [`enhanced-resolve`](https://github.com/webpack/enhanced-resolve) or
+> [`import-meta-resolve`](https://github.com/wooorm/import-meta-resolve)
+> instead.
+
+> [!NOTE]
+> This is an ESM-only module. It cannot be used from CommonJS.
+
+### `resolve`
+
+This library exports a single function, `resolve`, which can be used to resolve
+a package specifier to its path and format (e.g., `module`, `commonjs`).
+
+It takes the following arguments:
+
+| Name                 | Type                  | Optional | Description                                                                                                                                      |
+| :------------------- | :-------------------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **packageSpecifier** | `string`              | No       | The specifier to resolve, e.g., `@ts-bridge/resolver`, or `some-module/sub-path`.                                                                |
+| **parentUrl**        | `string \| URL`       | No       | The URL to start resolving from. This can be an (absolute) path, or instance of `URL`.                                                           |
+| **fileSystem**       | `FileSystemInterface` | Yes      | The file system to use for the resolution. This is mainly used for testing purposes, but can be used to use the resolver on custom file systems. |
+
+#### Example
+
+```ts
+import { resolve } from '@ts-bridge/resolver';
+
+const { path, format } = resolve('some-es-module/sub-path', import.meta.url);
+console.log(path); // "/path/to/node_modules/some-es-module/dist/sub-path.mjs"
+console.log(format); // "module"
+```

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
+    "@ts-bridge/test-utils": "workspace:^",
     "typescript": "^5.4.5",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.0"

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@ts-bridge/resolver",
+  "version": "0.0.0",
+  "description": "An implementation of the Node.js module resolution algorithm.",
+  "keywords": [
+    "build-tool",
+    "cjs",
+    "commonjs",
+    "development",
+    "esm",
+    "es-modules",
+    "module",
+    "hybrid",
+    "resolver",
+    "module-resolution",
+    "tsc",
+    "tsconfig",
+    "typescript"
+  ],
+  "homepage": "https://github.com/ts-bridge/ts-bridge/tree/main/packages/resolver#readme",
+  "bugs": {
+    "url": "https://github.com/ts-bridge/ts-bridge/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ts-bridge/ts-bridge.git"
+  },
+  "license": "MIT",
+  "author": "Maarten Zuidhoorn <maarten@zuidhoorn.com>",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "allow-scripts": "yarn workspace @ts-bridge/root allow-scripts",
+    "build": "tsc --project tsconfig.build.json",
+    "lint:changelog": "../../scripts/validate-changelog.sh @ts-bridge/resolver",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@metamask/auto-changelog": "^3.4.4",
+    "typescript": "^5.4.5",
+    "vite-tsconfig-paths": "^4.3.2",
+    "vitest": "^1.5.0"
+  },
+  "packageManager": "yarn@4.1.1",
+  "engines": {
+    "node": "^18.18 || >=20"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/resolver/src/constants.test.ts
+++ b/packages/resolver/src/constants.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_CONDITIONS } from './constants.js';
+
+describe('DEFAULT_CONDITIONS', () => {
+  it('is defined', () => {
+    expect(DEFAULT_CONDITIONS).toBeDefined();
+    expect(DEFAULT_CONDITIONS).toBeInstanceOf(Array);
+  });
+});

--- a/packages/resolver/src/constants.ts
+++ b/packages/resolver/src/constants.ts
@@ -1,1 +1,5 @@
-export const DEFAULT_CONDITIONS = ['node', 'import'];
+/**
+ * Default conditions for the resolver. These are the fields that are checked in
+ * order to resolve an import from the `package.json` exports field.
+ */
+export const DEFAULT_CONDITIONS = ['node', 'import', 'require'];

--- a/packages/resolver/src/constants.ts
+++ b/packages/resolver/src/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_CONDITIONS = ['node', 'import'];

--- a/packages/resolver/src/errors.test.ts
+++ b/packages/resolver/src/errors.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  InvalidModuleSpecifierError,
+  InvalidPackageConfigurationError,
+  InvalidPackageTargetError,
+  ModuleNotFoundError,
+  PackageImportNotDefinedError,
+  PackagePathNotExportedError,
+  UnsupportedDirectoryImportError,
+} from './errors.js';
+
+describe('InvalidModuleSpecifierError', () => {
+  it('is an error', () => {
+    const error = new InvalidModuleSpecifierError('invalid');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe(
+      'Module specifier is an invalid URL, package name or package subpath specifier: "invalid".',
+    );
+  });
+});
+
+describe('UnsupportedDirectoryImportError', () => {
+  it('is an error', () => {
+    const error = new UnsupportedDirectoryImportError('invalid');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe(
+      'The resolved path corresponds to a directory, which is not a supported target for module imports: "invalid".',
+    );
+  });
+});
+
+describe('ModuleNotFoundError', () => {
+  it('is an error', () => {
+    const error = new ModuleNotFoundError('invalid');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe(
+      'The package or module requested does not exist: "invalid".',
+    );
+  });
+});
+
+describe('InvalidPackageConfigurationError', () => {
+  it('is an error', () => {
+    const error = new InvalidPackageConfigurationError('invalid');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe(
+      '`package.json` configuration is invalid or contains an invalid configuration: "invalid".',
+    );
+  });
+});
+
+describe('InvalidPackageTargetError', () => {
+  it('is an error', () => {
+    const error = new InvalidPackageTargetError('invalid');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe(
+      'Package exports or imports define a target module for the package that is an invalid type or string target: "invalid".',
+    );
+  });
+});
+
+describe('PackagePathNotExportedError', () => {
+  it('is an error', () => {
+    const error = new PackagePathNotExportedError('invalid');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe(
+      'Package exports do not define or permit a target subpath in the package for the given module: "invalid".',
+    );
+  });
+});
+
+describe('PackageImportNotDefinedError', () => {
+  it('is an error', () => {
+    const error = new PackageImportNotDefinedError('invalid');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe(
+      'Package imports do not define the specifier: "invalid".',
+    );
+  });
+});

--- a/packages/resolver/src/errors.ts
+++ b/packages/resolver/src/errors.ts
@@ -1,0 +1,55 @@
+export class InvalidModuleSpecifierError extends Error {
+  constructor(moduleSpecifier: string) {
+    super(
+      `Module specifier is an invalid URL, package name or package subpath specifier: "${moduleSpecifier}".`,
+    );
+  }
+}
+
+export class UnsupportedDirectoryImportError extends Error {
+  constructor(moduleSpecifier: string) {
+    super(
+      `The resolved path corresponds to a directory, which is not a supported target for module imports: "${moduleSpecifier}".`,
+    );
+  }
+}
+
+export class ModuleNotFoundError extends Error {
+  constructor(moduleSpecifier: string) {
+    super(
+      `The package or module requested does not exist: "${moduleSpecifier}".`,
+    );
+  }
+}
+
+export class InvalidPackageConfigurationError extends Error {
+  constructor(packageUrl: string) {
+    super(
+      `\`package.json\` configuration is invalid or contains an invalid configuration: "${packageUrl}".`,
+    );
+  }
+}
+
+export class InvalidPackageTargetError extends Error {
+  constructor(target: string) {
+    super(
+      `Package exports or imports define a target module for the package that is an invalid type or string target: "${target}".`,
+    );
+  }
+}
+
+export class PackagePathNotExportedError extends Error {
+  constructor(packageSubpath: string) {
+    super(
+      `Package exports do not define or permit a target subpath in the package for the given module: "${packageSubpath}".`,
+    );
+  }
+}
+
+export class PackageImportNotDefinedError extends Error {
+  constructor(packageSpecifier: string) {
+    super(
+      `Package imports do not define the specifier: "${packageSpecifier}".`,
+    );
+  }
+}

--- a/packages/resolver/src/errors.ts
+++ b/packages/resolver/src/errors.ts
@@ -1,4 +1,14 @@
+/**
+ * An error that is thrown when a module specifier is an invalid URL, package
+ * name or package subpath specifier.
+ */
 export class InvalidModuleSpecifierError extends Error {
+  /**
+   * Create a new `InvalidModuleSpecifierError`.
+   *
+   * @param moduleSpecifier - The module specifier that is invalid.
+   * @returns A new `InvalidModuleSpecifierError`.
+   */
   constructor(moduleSpecifier: string) {
     super(
       `Module specifier is an invalid URL, package name or package subpath specifier: "${moduleSpecifier}".`,
@@ -6,7 +16,16 @@ export class InvalidModuleSpecifierError extends Error {
   }
 }
 
+/**
+ * An error that is thrown when a module specifier is a directory.
+ */
 export class UnsupportedDirectoryImportError extends Error {
+  /**
+   * Create a new `UnsupportedDirectoryImportError`.
+   *
+   * @param moduleSpecifier - The module specifier that is a directory.
+   * @returns A new `UnsupportedDirectoryImportError`.
+   */
   constructor(moduleSpecifier: string) {
     super(
       `The resolved path corresponds to a directory, which is not a supported target for module imports: "${moduleSpecifier}".`,
@@ -14,7 +33,16 @@ export class UnsupportedDirectoryImportError extends Error {
   }
 }
 
+/**
+ * An error that is thrown when a package is not found.
+ */
 export class ModuleNotFoundError extends Error {
+  /**
+   * Create a new `ModuleNotFoundError`.
+   *
+   * @param moduleSpecifier - The module specifier that is not found.
+   * @returns A new `ModuleNotFoundError`.
+   */
   constructor(moduleSpecifier: string) {
     super(
       `The package or module requested does not exist: "${moduleSpecifier}".`,
@@ -22,7 +50,16 @@ export class ModuleNotFoundError extends Error {
   }
 }
 
+/**
+ * An error that is thrown when a `package.json` configuration is invalid.
+ */
 export class InvalidPackageConfigurationError extends Error {
+  /**
+   * Create a new `InvalidPackageConfigurationError`.
+   *
+   * @param packageUrl - The URL of the `package.json` file.
+   * @returns A new `InvalidPackageConfigurationError`.
+   */
   constructor(packageUrl: string) {
     super(
       `\`package.json\` configuration is invalid or contains an invalid configuration: "${packageUrl}".`,
@@ -30,7 +67,16 @@ export class InvalidPackageConfigurationError extends Error {
   }
 }
 
+/**
+ * An error that is thrown when a package exports configuration is invalid.
+ */
 export class InvalidPackageTargetError extends Error {
+  /**
+   * Create a new `InvalidPackageTargetError`.
+   *
+   * @param target - The target of the package exports.
+   * @returns A new `InvalidPackageTargetError`.
+   */
   constructor(target: string) {
     super(
       `Package exports or imports define a target module for the package that is an invalid type or string target: "${target}".`,
@@ -38,7 +84,16 @@ export class InvalidPackageTargetError extends Error {
   }
 }
 
+/**
+ * An error that is thrown when a package subpath is not exported.
+ */
 export class PackagePathNotExportedError extends Error {
+  /**
+   * Create a new `PackagePathNotExportedError`.
+   *
+   * @param packageSubpath - The subpath of the package that is not exported.
+   * @returns A new `PackagePathNotExportedError`.
+   */
   constructor(packageSubpath: string) {
     super(
       `Package exports do not define or permit a target subpath in the package for the given module: "${packageSubpath}".`,
@@ -46,7 +101,16 @@ export class PackagePathNotExportedError extends Error {
   }
 }
 
+/**
+ * An error that is thrown when a package import is not defined.
+ */
 export class PackageImportNotDefinedError extends Error {
+  /**
+   * Create a new `PackageImportNotDefinedError`.
+   *
+   * @param packageSpecifier - The package specifier that is not defined.
+   * @returns A new `PackageImportNotDefinedError`.
+   */
   constructor(packageSpecifier: string) {
     super(
       `Package imports do not define the specifier: "${packageSpecifier}".`,

--- a/packages/resolver/src/file-system.test.ts
+++ b/packages/resolver/src/file-system.test.ts
@@ -1,0 +1,77 @@
+import { getPathFromRoot } from '@ts-bridge/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_FILE_SYSTEM } from './file-system.js';
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const { isDirectory, isFile, readFile, readBytes } = DEFAULT_FILE_SYSTEM;
+
+describe('DEFAULT_FILE_SYSTEM', () => {
+  describe('isDirectory', () => {
+    it('returns true for directories', () => {
+      expect(isDirectory(getPathFromRoot(''))).toBe(true);
+    });
+
+    it('returns false for files', () => {
+      expect(isDirectory(getPathFromRoot('package.json'))).toBe(false);
+    });
+
+    it('returns false for non-existent paths', () => {
+      expect(isDirectory(getPathFromRoot('non-existent'))).toBe(false);
+    });
+  });
+
+  describe('isFile', () => {
+    it('returns true for files', () => {
+      expect(isFile(getPathFromRoot('package.json'))).toBe(true);
+    });
+
+    it('returns false for directories', () => {
+      expect(isFile(getPathFromRoot(''))).toBe(false);
+    });
+
+    it('returns false for non-existent paths', () => {
+      expect(isFile(getPathFromRoot('non-existent'))).toBe(false);
+    });
+  });
+
+  describe('readFile', () => {
+    it('reads the contents of a file', () => {
+      expect(readFile(getPathFromRoot('package.json'))).toContain(
+        '"name": "@ts-bridge/root"',
+      );
+    });
+
+    it('throws an error for directories', () => {
+      expect(() => readFile(getPathFromRoot(''))).toThrow(
+        'EISDIR: illegal operation on a directory, read',
+      );
+    });
+
+    it('throws an error for non-existent paths', () => {
+      expect(() => readFile(getPathFromRoot('non-existent'))).toThrow(
+        'ENOENT: no such file or directory, open',
+      );
+    });
+  });
+
+  describe('readBytes', () => {
+    it('reads a specific number of bytes from a file', () => {
+      expect(readBytes(getPathFromRoot('package.json'), 10)).toEqual(
+        new Uint8Array([123, 10, 32, 32, 34, 110, 97, 109, 101, 34]),
+      );
+    });
+
+    it('throws an error for directories', () => {
+      expect(() => readBytes(getPathFromRoot(''), 10)).toThrow(
+        'EISDIR: illegal operation on a directory, read',
+      );
+    });
+
+    it('throws an error for non-existent paths', () => {
+      expect(() => readBytes(getPathFromRoot('non-existent'), 10)).toThrow(
+        'ENOENT: no such file or directory, open',
+      );
+    });
+  });
+});

--- a/packages/resolver/src/file-system.ts
+++ b/packages/resolver/src/file-system.ts
@@ -1,0 +1,79 @@
+import { statSync, readFileSync, openSync, readSync, closeSync } from 'fs';
+
+/**
+ * Interface for file system operations.
+ *
+ * This interface is used to abstract file system operations in order to make
+ * the module resolver platform-agnostic.
+ */
+export type FileSystemInterface = {
+  /**
+   * Check if the given path is a directory.
+   *
+   * @param path - The path to check.
+   * @returns `true` if the path is a directory, `false` otherwise.
+   */
+  isDirectory(path: string): boolean;
+
+  /**
+   * Check if the given path is a file.
+   *
+   * @param path - The path to check.
+   * @returns `true` if the path is a file, `false` otherwise.
+   */
+  isFile(path: string): boolean;
+
+  /**
+   * Read the contents of a file.
+   *
+   * @param path - The path to the file.
+   * @returns The contents of the file.
+   */
+  readFile(path: string): string;
+
+  /**
+   * Read a specific number of bytes from a file.
+   *
+   * @param path - The path to the file.
+   * @param length - The number of bytes to read.
+   * @returns The bytes read from the file.
+   */
+  readBytes(path: string, length: number): Uint8Array;
+};
+
+/**
+ * Default file system implementation using Node.js file system APIs.
+ */
+export const DEFAULT_FILE_SYSTEM: FileSystemInterface = {
+  isDirectory(path: string): boolean {
+    try {
+      const stat = statSync(path);
+      return stat.isDirectory();
+    } catch {
+      return false;
+    }
+  },
+
+  isFile(path: string): boolean {
+    try {
+      const stat = statSync(path);
+      return stat.isFile();
+    } catch {
+      return false;
+    }
+  },
+
+  readFile(path: string): string {
+    return readFileSync(path, 'utf-8');
+  },
+
+  readBytes(path: string, length: number): Uint8Array {
+    const buffer = new Uint8Array(length);
+    const descriptor = openSync(path, 'r');
+
+    readSync(descriptor, buffer, 0, length, 0);
+    closeSync(descriptor);
+
+    return buffer;
+  },
+};

--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -1,0 +1,1 @@
+export { resolve } from './resolver.js';

--- a/packages/resolver/src/resolver.test.ts
+++ b/packages/resolver/src/resolver.test.ts
@@ -1,21 +1,1275 @@
-import { describe, expect, it } from 'vitest';
+import { getFileSystem, getPathFromRoot } from '@ts-bridge/test-utils';
+import { describe, expect, it, vi } from 'vitest';
 
-import { resolve } from './resolver.js';
+import { comparePatternKeys, resolve } from './resolver.js';
+import { isFlagEnabled } from './utils.js';
+
+vi.mock('./utils.js', async (importOriginal) => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    ...(await importOriginal<typeof import('./utils.js')>()),
+    isFlagEnabled: vi.fn().mockReturnValue(false),
+  };
+});
 
 describe('resolve', () => {
-  it('resolves a package', () => {
-    expect(resolve('vite/runtime', import.meta.url)).toStrictEqual({
-      path: expect.stringContaining(
-        'ts-bridge/node_modules/vite/dist/node/runtime.js',
-      ),
-      format: 'module',
+  describe('`file:` URLs', () => {
+    it('resolves a file URL', () => {
+      const fileSystem = getFileSystem({
+        '/path/to/file.js': 'console.log("hello!");',
+      });
+
+      expect(
+        resolve('file:///path/to/file.js', import.meta.url, fileSystem, false),
+      ).toStrictEqual({
+        path: '/path/to/file.js',
+        format: 'commonjs',
+      });
     });
 
-    expect(resolve('typescript', import.meta.url)).toStrictEqual({
-      path: expect.stringContaining(
-        'ts-bridge/node_modules/typescript/lib/typescript.js',
-      ),
-      format: 'commonjs',
+    it('resolves a CommonJS file', () => {
+      const fileSystem = getFileSystem({
+        '/path/to/file.cjs': 'console.log("hello!");',
+      });
+
+      expect(
+        resolve('file:///path/to/file.cjs', import.meta.url, fileSystem, false),
+      ).toStrictEqual({
+        path: '/path/to/file.cjs',
+        format: 'commonjs',
+      });
     });
+
+    it('resolves a ES module file', () => {
+      const fileSystem = getFileSystem({
+        '/path/to/file.mjs': 'console.log("hello!");',
+      });
+
+      expect(
+        resolve('file:///path/to/file.mjs', import.meta.url, fileSystem, false),
+      ).toStrictEqual({
+        path: '/path/to/file.mjs',
+        format: 'module',
+      });
+    });
+
+    it('resolves a JSON module file', () => {
+      const fileSystem = getFileSystem({
+        '/path/to/file.json': '{"hello": "world"}',
+      });
+
+      expect(
+        resolve(
+          'file:///path/to/file.json',
+          import.meta.url,
+          fileSystem,
+          false,
+        ),
+      ).toStrictEqual({
+        path: '/path/to/file.json',
+        format: 'json',
+      });
+    });
+
+    it('resolves a WASM module file if `--experimental-wasm-modules` is enabled', () => {
+      vi.mocked(isFlagEnabled).mockReturnValue(true);
+
+      const fileSystem = getFileSystem({
+        '/path/to/file.wasm': 'wasm code',
+      });
+
+      expect(
+        resolve(
+          'file:///path/to/file.wasm',
+          import.meta.url,
+          fileSystem,
+          false,
+        ),
+      ).toStrictEqual({
+        path: '/path/to/file.wasm',
+        format: 'wasm',
+      });
+
+      vi.mocked(isFlagEnabled).mockReturnValue(false);
+    });
+
+    it('resolves a WASM module file if `--experimental-wasm-modules` is enabled, the file does not have an extension, and the file starts with the WASM magic bytes', () => {
+      vi.mocked(isFlagEnabled).mockReturnValue(true);
+
+      const fileSystem = getFileSystem({
+        '/path/to/file': new Uint8Array([0x00, 0x61, 0x73, 0x6d]),
+      });
+
+      expect(
+        resolve('file:///path/to/file', import.meta.url, fileSystem, false),
+      ).toStrictEqual({
+        path: '/path/to/file',
+        format: 'wasm',
+      });
+
+      vi.mocked(isFlagEnabled).mockReturnValue(false);
+    });
+
+    it('does not resolve a WASM module file if `--experimental-wasm-modules` is disabled', () => {
+      vi.mocked(isFlagEnabled).mockReturnValue(false);
+
+      const fileSystem = getFileSystem({
+        '/path/to/file.wasm': 'wasm code',
+      });
+
+      expect(
+        resolve(
+          'file:///path/to/file.wasm',
+          import.meta.url,
+          fileSystem,
+          false,
+        ),
+      ).toStrictEqual({
+        path: '/path/to/file.wasm',
+        format: null,
+      });
+    });
+
+    it('does not resolve a WASM module file if `--experimental-wasm-modules` is enabled, the file does not have an extension, and the file does not start with the WASM magic bytes', () => {
+      vi.mocked(isFlagEnabled).mockReturnValue(true);
+
+      const fileSystem = getFileSystem({
+        '/path/to/file': new Uint8Array([0x00, 0x01, 0x02, 0x03]),
+        '/path/to/package.json': JSON.stringify({
+          type: 'module',
+        }),
+      });
+
+      expect(
+        resolve('file:///path/to/file', import.meta.url, fileSystem, false),
+      ).toStrictEqual({
+        path: '/path/to/file',
+        format: 'module',
+      });
+
+      vi.mocked(isFlagEnabled).mockReturnValue(false);
+    });
+
+    it('does not resolve a WASM module file if `--experimental-wasm-modules` is disabled, and the file does not have an extension', () => {
+      vi.mocked(isFlagEnabled).mockReturnValue(false);
+
+      const fileSystem = getFileSystem({
+        '/path/to/file': new Uint8Array([0x00, 0x01, 0x02, 0x03]),
+        '/path/to/package.json': JSON.stringify({
+          type: 'module',
+        }),
+      });
+
+      expect(
+        resolve('file:///path/to/file', import.meta.url, fileSystem, false),
+      ).toStrictEqual({
+        path: '/path/to/file',
+        format: 'module',
+      });
+
+      vi.mocked(isFlagEnabled).mockReturnValue(false);
+    });
+
+    it('does not resolve a WASM module file if `--experimental-wasm-modules` is disabled, and the file does not have an extension, and there is no `package.json`', () => {
+      vi.mocked(isFlagEnabled).mockReturnValue(false);
+
+      const fileSystem = getFileSystem({
+        '/path/to/file': new Uint8Array([0x00, 0x01, 0x02, 0x03]),
+      });
+
+      expect(
+        resolve('file:///path/to/file', import.meta.url, fileSystem, false),
+      ).toStrictEqual({
+        path: '/path/to/file',
+        format: null,
+      });
+
+      vi.mocked(isFlagEnabled).mockReturnValue(false);
+    });
+
+    it('throws an error if the file is a directory', () => {
+      const fileSystem = getFileSystem({
+        '/path/to/directory': { type: 'directory' },
+      });
+
+      expect(() =>
+        resolve(
+          'file:///path/to/directory',
+          import.meta.url,
+          fileSystem,
+          false,
+        ),
+      ).toThrow(
+        'The resolved path corresponds to a directory, which is not a supported target for module imports: "file:///path/to/directory".',
+      );
+    });
+
+    it('throws an error if the file does not exist', () => {
+      const fileSystem = getFileSystem();
+
+      expect(() =>
+        resolve(
+          'file:///path/to/missing.js',
+          import.meta.url,
+          fileSystem,
+          false,
+        ),
+      ).toThrow(
+        'The package or module requested does not exist: "file:///path/to/missing.js".',
+      );
+    });
+  });
+
+  describe('`node:` URLs', () => {
+    it('resolves a builtin module', () => {
+      expect(resolve('node:fs', import.meta.url)).toStrictEqual({
+        path: 'node:fs',
+        format: 'builtin',
+      });
+    });
+
+    it('resolves a builtin module without the `node:` prefix', () => {
+      expect(resolve('path', import.meta.url)).toStrictEqual({
+        path: 'node:path',
+        format: 'builtin',
+      });
+    });
+  });
+
+  describe('`data:` URLs', () => {
+    it('resolves a JavaScript module', () => {
+      expect(
+        resolve('data:text/javascript,console.log("hello!");', import.meta.url),
+      ).toStrictEqual({
+        path: 'data:text/javascript,console.log("hello!");',
+        format: 'module',
+      });
+    });
+
+    it('resolves a JSON module', () => {
+      expect(
+        resolve('data:application/json,"world!"', import.meta.url),
+      ).toStrictEqual({
+        path: 'data:application/json,"world!"',
+        format: 'json',
+      });
+    });
+
+    it('resolves a WebAssembly module', () => {
+      expect(
+        resolve(
+          'data:application/wasm,base64,AGFzbQEAAAABCAJgAn9/AX8DAgA=',
+          import.meta.url,
+        ),
+      ).toStrictEqual({
+        path: 'data:application/wasm,base64,AGFzbQEAAAABCAJgAn9/AX8DAgA=',
+        format: 'wasm',
+      });
+    });
+  });
+
+  describe('`http:` URLs', () => {
+    it('returns `null` as format', () => {
+      expect(
+        resolve('http://example.com/file.js', import.meta.url),
+      ).toStrictEqual({
+        path: 'http://example.com/file.js',
+        format: null,
+      });
+    });
+  });
+
+  describe('file paths', () => {
+    it('resolves a relative path', () => {
+      const fileSystem = getFileSystem({
+        '/path/to/directory/file.js': 'console.log("hello!");',
+      });
+
+      expect(
+        resolve('./file.js', 'file:///path/to/directory/', fileSystem, false),
+      ).toStrictEqual({
+        path: '/path/to/directory/file.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves an absolute path', () => {
+      const fileSystem = getFileSystem({
+        '/file.js': 'console.log("hello!");',
+      });
+
+      expect(
+        resolve('/file.js', 'file:///path/to/directory/', fileSystem, false),
+      ).toStrictEqual({
+        path: '/file.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('throws an error if the file is a directory', () => {
+      const fileSystem = getFileSystem({
+        '/path/to/directory': { type: 'directory' },
+      });
+
+      expect(() =>
+        resolve(
+          '/path/to/directory',
+          'file:///path/to/directory/',
+          fileSystem,
+          false,
+        ),
+      ).toThrow(
+        'The resolved path corresponds to a directory, which is not a supported target for module imports: "file:///path/to/directory".',
+      );
+    });
+
+    it('throws an error if the file does not exist', () => {
+      const fileSystem = getFileSystem();
+
+      expect(() =>
+        resolve(
+          '/path/to/missing.js',
+          'file:///path/to/directory/',
+          fileSystem,
+        ),
+      ).toThrow(
+        'The package or module requested does not exist: "file:///path/to/missing.js".',
+      );
+    });
+  });
+
+  describe('imports', () => {
+    it('resolves an import', () => {
+      const fileSystem = getFileSystem({
+        '/foo/module.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          imports: {
+            '#module': './module.js',
+          },
+        }),
+      });
+
+      expect(
+        resolve('#module', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/module.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves an import not starting with `./`', () => {
+      const fileSystem = getFileSystem({
+        '/foo/module.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          imports: {
+            '#module': 'fs',
+          },
+        }),
+      });
+
+      expect(
+        resolve('#module', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: 'node:fs',
+        format: 'builtin',
+      });
+    });
+
+    it('resolves a wildcard import', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          imports: {
+            '#foo/*': './*.js',
+          },
+        }),
+      });
+
+      expect(
+        resolve('#foo/bar', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/bar.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves a wildcard import for an import not starting with `./`', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          imports: {
+            '#foo/*': '*',
+          },
+        }),
+      });
+
+      expect(
+        resolve('#foo/fs', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: 'node:fs',
+        format: 'builtin',
+      });
+    });
+
+    it('throws an error if the import is "#"', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          imports: {
+            '#': './bar.js',
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('#', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Module specifier is an invalid URL, package name or package subpath specifier: "#".',
+      );
+    });
+
+    it('throws an error if the import starts with "#/"', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          imports: {
+            '#/foo': './bar.js',
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('#/foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Module specifier is an invalid URL, package name or package subpath specifier: "#/foo".',
+      );
+    });
+
+    it('throws an error if the import does not exist', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          imports: {
+            '#foo/*': './*.js',
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('#bar', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow('Package imports do not define the specifier: "#bar".');
+    });
+
+    it('throws an error if the referenced file does not exist', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          imports: {
+            '#foo/*': './*.js',
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('#foo/baz', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'The package or module requested does not exist: "file:///foo/baz.js".',
+      );
+    });
+
+    it('throws an error if there is no `package.json`', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+      });
+
+      expect(() =>
+        resolve('#foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow('Package imports do not define the specifier: "#foo".');
+    });
+
+    it('throws an error if the imports in `package.json` is not an object', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          imports: ['#foo'],
+        }),
+      });
+
+      expect(() =>
+        resolve('#foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow('Package imports do not define the specifier: "#foo".');
+    });
+
+    it.each(['../', '/'])(
+      'throws an error if the import starts with `%s`',
+      (segment) => {
+        const fileSystem = getFileSystem({
+          '/foo/bar.js': 'console.log("hello!");',
+          '/foo/package.json': JSON.stringify({
+            imports: {
+              '#foo': `${segment}foo.js`,
+            },
+          }),
+        });
+
+        expect(() =>
+          resolve('#foo', 'file:///foo/bar.js', fileSystem, false),
+        ).toThrow(
+          `Package exports or imports define a target module for the package that is an invalid type or string target: "${segment}foo.js".`,
+        );
+      },
+    );
+
+    it('throws an error if the import is a valid URL', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          imports: {
+            '#foo': 'file:///foo.js',
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('#foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Package exports or imports define a target module for the package that is an invalid type or string target: "file:///foo.js".',
+      );
+    });
+
+    it.each(['', '.', '..', 'node_modules'])(
+      'throws an error if the import contains a "%s" segment after the first "."',
+      (segment) => {
+        const fileSystem = getFileSystem({
+          '/foo/bar.js': 'console.log("hello!");',
+          '/foo/package.json': JSON.stringify({
+            name: 'foo',
+            imports: {
+              '#foo': `./${segment}/bar.js`,
+            },
+          }),
+        });
+
+        expect(() =>
+          resolve('#foo', 'file:///foo/bar.js', fileSystem, false),
+        ).toThrow(
+          `Package exports or imports define a target module for the package that is an invalid type or string target: "./${segment}/bar.js".`,
+        );
+      },
+    );
+
+    it.each(['', '.', '..', 'node_modules'])(
+      'throws an error if the import pattern contains a "%s" segment after the first "."',
+      (segment) => {
+        const fileSystem = getFileSystem({
+          '/foo/bar.js': 'console.log("hello!");',
+          '/foo/package.json': JSON.stringify({
+            name: 'foo',
+            imports: {
+              '#foo/*': `./*/bar.js`,
+            },
+          }),
+        });
+
+        expect(() =>
+          resolve(
+            `#foo/${segment}/bar.js`,
+            'file:///foo/bar.js',
+            fileSystem,
+            false,
+          ),
+        ).toThrow(
+          `Module specifier is an invalid URL, package name or package subpath specifier: "${segment}/bar.js".`,
+        );
+      },
+    );
+  });
+
+  describe('exports', () => {
+    it('resolves an object export', () => {
+      const fileSystem = getFileSystem({
+        '/foo/module.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            '.': './module.js',
+          },
+        }),
+      });
+
+      expect(
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/module.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves an object export with a previous condition not resolving', () => {
+      const fileSystem = getFileSystem({
+        '/foo/module.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            '.': {
+              default: null,
+              node: './module.js',
+            },
+          },
+        }),
+      });
+
+      expect(
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/module.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves a wildcard object export', () => {
+      const fileSystem = getFileSystem({
+        '/foo/dist/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            './*': './dist/*.js',
+          },
+        }),
+      });
+
+      expect(
+        resolve('foo/bar', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/dist/bar.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves a wildcard object export with a pattern trailer', () => {
+      const fileSystem = getFileSystem({
+        '/foo/dist/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            './*/trailer': './dist/*.js',
+          },
+        }),
+      });
+
+      expect(
+        resolve('foo/bar/trailer', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/dist/bar.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves an object export with multiple wildcards', () => {
+      const fileSystem = getFileSystem({
+        '/foo/dist/bar.js': 'console.log("hello!");',
+        '/foo/dist/baz.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            './*/baz': './dist/*/baz.js',
+            './*': './dist/*.js',
+          },
+        }),
+      });
+
+      expect(
+        resolve('foo/bar', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/dist/bar.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves an object export with multiple wildcards in order of specificity', () => {
+      const fileSystem = getFileSystem({
+        '/foo/dist/bar.js': 'console.log("hello!");',
+        '/foo/dist/bar/baz.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            './*': './dist/*.js',
+            './specific/*': './dist/*/baz.js',
+          },
+        }),
+      });
+
+      expect(
+        resolve('foo/specific/bar', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/dist/bar/baz.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves an object export with multiple wildcards and non-wildcards in order of specificity', () => {
+      const fileSystem = getFileSystem({
+        '/foo/dist/b.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            './*': './dist/*.js',
+            './a/*': './dist/a.js',
+            './a/b': './dist/b.js',
+          },
+        }),
+      });
+
+      expect(
+        resolve('foo/a/b', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/dist/b.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves a string export', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: './bar.js',
+        }),
+      });
+
+      expect(
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/bar.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves an array export', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: ['./bar.js', './baz.js'],
+        }),
+      });
+
+      expect(
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/bar.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves an array export with an invalid target', () => {
+      const fileSystem = getFileSystem({
+        '/foo/baz.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: [0, './baz.js'],
+        }),
+      });
+
+      expect(
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/baz.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('throws an error if the export does not exist', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            '.': './dist/*.js',
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('foo/baz', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Package exports do not define or permit a target subpath in the package for the given module: "./baz".',
+      );
+    });
+
+    it('throws an error if the referenced file does not exist', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          exports: {
+            './*': './*.js',
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('foo/baz', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow('The package or module requested does not exist: "foo/baz".');
+    });
+
+    it('throws an error if a string export does not start with `./`', () => {
+      const fileSystem = getFileSystem({
+        '/foo/bar.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: 'bar.js',
+        }),
+      });
+
+      expect(() =>
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Package exports or imports define a target module for the package that is an invalid type or string target: "bar.js".',
+      );
+    });
+
+    it.each(['', '.', '..', 'node_modules'])(
+      'throws an error if a string export contains a "%s" segment after the first "."',
+      (segment) => {
+        const fileSystem = getFileSystem({
+          '/foo/bar.js': 'console.log("hello!");',
+          '/foo/package.json': JSON.stringify({
+            name: 'foo',
+            exports: `./${segment}/bar.js`,
+          }),
+        });
+
+        expect(() =>
+          resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+        ).toThrow(
+          `Package exports or imports define a target module for the package that is an invalid type or string target: "./${segment}/bar.js".`,
+        );
+      },
+    );
+
+    it('throws an error if all targets in an array are invalid', () => {
+      const fileSystem = getFileSystem({
+        '/foo/baz.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: [0, 1],
+        }),
+      });
+
+      expect(() =>
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Package exports or imports define a target module for the package that is an invalid type or string target: "/foo".',
+      );
+    });
+
+    it('throws an error if all targets in an array are invalid', () => {
+      const fileSystem = getFileSystem({
+        '/foo/baz.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: [0, 1],
+        }),
+      });
+
+      expect(() =>
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Package exports or imports define a target module for the package that is an invalid type or string target: "/foo".',
+      );
+    });
+
+    it('throws an error if no target in an array resolves', () => {
+      const fileSystem = getFileSystem({
+        '/foo/baz.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: [null],
+        }),
+      });
+
+      expect(() =>
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Package exports do not define or permit a target subpath in the package for the given module: ".".',
+      );
+    });
+
+    it('throws an error if the array is empty', () => {
+      const fileSystem = getFileSystem({
+        '/foo/baz.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: [],
+        }),
+      });
+
+      expect(() =>
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Package exports do not define or permit a target subpath in the package for the given module: ".".',
+      );
+    });
+
+    it('throws an error if the conditions in an object are not met', () => {
+      const fileSystem = getFileSystem({
+        '/foo/baz.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            '.': {
+              browser: './bar.js',
+            },
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Package exports do not define or permit a target subpath in the package for the given module: ".".',
+      );
+    });
+
+    it('throws an error if the package does not export "."', () => {
+      const fileSystem = getFileSystem({
+        '/foo/baz.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            './bar': {
+              browser: './bar.js',
+            },
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Package exports do not define or permit a target subpath in the package for the given module: ".".',
+      );
+    });
+
+    it('throws an error if the package does not have relative exports', () => {
+      const fileSystem = getFileSystem({
+        '/foo/baz.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            bar: {
+              browser: './bar.js',
+            },
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('foo/bar', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow(
+        'Package exports do not define or permit a target subpath in the package for the given module: "./bar".',
+      );
+    });
+  });
+
+  describe('externals', () => {
+    it('resolves an external ES module package', () => {
+      expect(resolve('vite', import.meta.url)).toStrictEqual({
+        path: getPathFromRoot('node_modules/vite/dist/node/index.js'),
+        format: 'module',
+      });
+    });
+
+    it('resolves an external ES module with a subpath', () => {
+      expect(resolve('vite/runtime', import.meta.url)).toStrictEqual({
+        path: getPathFromRoot('node_modules/vite/dist/node/runtime.js'),
+        format: 'module',
+      });
+    });
+
+    it('resolves an external ES module with a wildcard export', () => {
+      expect(
+        resolve('vite/dist/client/env.mjs', import.meta.url),
+      ).toStrictEqual({
+        path: getPathFromRoot('node_modules/vite/dist/client/env.mjs'),
+        format: 'module',
+      });
+    });
+
+    it('resolves an external CommonJS package', () => {
+      expect(resolve('typescript', import.meta.url)).toStrictEqual({
+        path: getPathFromRoot('node_modules/typescript/lib/typescript.js'),
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves an external JSON module', () => {
+      expect(resolve('vite/package.json', import.meta.url)).toStrictEqual({
+        path: getPathFromRoot('node_modules/vite/package.json'),
+        format: 'json',
+      });
+    });
+
+    it('resolves an external scoped ES module package', () => {
+      expect(resolve('@scure/base', import.meta.url)).toStrictEqual({
+        path: getPathFromRoot('node_modules/@scure/base/lib/esm/index.js'),
+        format: 'module',
+      });
+    });
+
+    it('resolves an external scoped CommonJS package', () => {
+      expect(resolve('@babel/core', import.meta.url)).toStrictEqual({
+        path: getPathFromRoot('node_modules/@babel/core/lib/index.js'),
+        format: 'commonjs',
+      });
+    });
+
+    it('resolves an external scoped JSON module', () => {
+      expect(
+        resolve('@typescript/vfs/package.json', import.meta.url),
+      ).toStrictEqual({
+        path: getPathFromRoot('node_modules/@typescript/vfs/package.json'),
+        format: 'json',
+      });
+    });
+
+    it('does not resolve an external package without a `package.json`', () => {
+      const fileSystem = getFileSystem({
+        '/foo/node_modules/bar': { type: 'directory' },
+        '/foo/node_modules/bar/index.js': 'console.log("hello!");',
+        '/foo/node_modules/bar/package.json': JSON.stringify({
+          name: 'bar',
+          main: 'index.js',
+        }),
+        '/foo/bar/node_modules/bar': { type: 'directory' },
+        '/foo/bar/node_modules/bar/index.js': 'console.log("hello!");',
+      });
+
+      expect(
+        resolve('bar', 'file:///foo/bar/baz.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/node_modules/bar/index.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('throws an error if the package specifier is empty', () => {
+      expect(() => resolve('', import.meta.url)).toThrow(
+        'Module specifier is an invalid URL, package name or package subpath specifier: "".',
+      );
+    });
+
+    it('throws an error if the package specifier contains a backslash', () => {
+      expect(() => resolve('vite\\runtime', import.meta.url)).toThrow(
+        'Module specifier is an invalid URL, package name or package subpath specifier: "vite\\runtime".',
+      );
+    });
+
+    it('throws an error if the package specifier contains a percent symbol', () => {
+      expect(() => resolve('vite%runtime', import.meta.url)).toThrow(
+        'Module specifier is an invalid URL, package name or package subpath specifier: "vite%runtime".',
+      );
+    });
+
+    it('throws an error if the package specifier subpath ends with a slash', () => {
+      expect(() => resolve('vite/runtime/', import.meta.url)).toThrow(
+        'Module specifier is an invalid URL, package name or package subpath specifier: "vite/runtime/".',
+      );
+    });
+
+    it('throws an error if the package does not exist', () => {
+      expect(() => resolve('missing-package', import.meta.url)).toThrow(
+        'The package or module requested does not exist: "missing-package".',
+      );
+    });
+
+    it('throws if the package specifier contains an `@` symbol, but does not have a slash', () => {
+      expect(() => resolve('@foo', import.meta.url)).toThrow(
+        'Module specifier is an invalid URL, package name or package subpath specifier: "@foo".',
+      );
+    });
+  });
+
+  describe('self', () => {
+    it('resolves the current module by the `package.json` name', () => {
+      const fileSystem = getFileSystem({
+        '/foo/module.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+          exports: {
+            '.': './module.js',
+          },
+        }),
+      });
+
+      expect(
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/module.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('throws an error if the `package.json` name does not match', () => {
+      const fileSystem = getFileSystem({
+        '/foo/module.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'bar',
+          exports: {
+            '.': './module.js',
+          },
+        }),
+      });
+
+      expect(() =>
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow('The package or module requested does not exist: "foo".');
+    });
+
+    it('throws an error if no `package.json` was found', () => {
+      const fileSystem = getFileSystem({
+        '/foo/module.js': 'console.log("hello!");',
+      });
+
+      expect(() =>
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow('The package or module requested does not exist: "foo".');
+    });
+
+    it('throws an error if `package.json` does not contain exports', () => {
+      const fileSystem = getFileSystem({
+        '/foo/module.js': 'console.log("hello!");',
+        '/foo/package.json': JSON.stringify({
+          name: 'foo',
+        }),
+      });
+
+      expect(() =>
+        resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+      ).toThrow('The package or module requested does not exist: "foo".');
+    });
+
+    it('throws an error if the current directory is "node_modules"', () => {
+      const fileSystem = getFileSystem({
+        '/foo/node_modules/bar/module.js': 'console.log("hello!");',
+      });
+
+      expect(() =>
+        resolve(
+          'foo',
+          'file:///foo/node_modules/bar/baz.js',
+          fileSystem,
+          false,
+        ),
+      ).toThrow('The package or module requested does not exist: "foo".');
+    });
+  });
+
+  it('caches the result of a resolution', () => {
+    const emptyFileSystem = getFileSystem();
+    const fileSystem = getFileSystem({
+      '/foo/module.js': 'console.log("hello!");',
+      '/foo/package.json': JSON.stringify({
+        name: 'foo',
+        exports: {
+          '.': './module.js',
+        },
+      }),
+    });
+
+    const first = resolve('foo', 'file:///foo/bar.js', fileSystem, true);
+
+    // The second call is done on an empty file system, but since the result is
+    // cached, the same result should be returned.
+    const second = resolve('foo', 'file:///foo/bar.js', emptyFileSystem, true);
+
+    expect(first).toBe(second);
+  });
+
+  it('throws an error if the specifier is invalid', () => {
+    expect(() => resolve('foo%2fbar', import.meta.url)).toThrow(
+      'Module specifier is an invalid URL, package name or package subpath specifier: "foo%2fbar".',
+    );
+  });
+
+  it('throws an error if the resolved path contains invalid characters', () => {
+    const fileSystem = getFileSystem({
+      '/foo/module.js': 'console.log("hello!");',
+      '/foo/package.json': JSON.stringify({
+        name: 'foo',
+        exports: {
+          '.': './foo%2fbar.js',
+        },
+      }),
+    });
+
+    expect(() =>
+      resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+    ).toThrow(
+      'Module specifier is an invalid URL, package name or package subpath specifier: "file:///foo/foo%2fbar.js".',
+    );
+  });
+
+  it('throws an error if the resolved `package.json` is null', () => {
+    const fileSystem = getFileSystem({
+      '/foo/module.js': 'console.log("hello!");',
+      '/foo/package.json': JSON.stringify(null),
+    });
+
+    expect(() =>
+      resolve('foo', 'file:///foo/bar.js', fileSystem, false),
+    ).toThrow(
+      '`package.json` configuration is invalid or contains an invalid configuration: "/foo".',
+    );
+  });
+});
+
+describe('comparePatternKeys', () => {
+  it('returns 1 if the A contains a wildcard', () => {
+    expect(comparePatternKeys('./*', './foo/')).toBe(1);
+  });
+
+  it('returns 1 if B is longer than A', () => {
+    expect(comparePatternKeys('./*', './foo/*')).toBe(1);
+  });
+
+  it('returns 1 if B is longer than A without wildcards', () => {
+    expect(comparePatternKeys('./', './foo/')).toBe(1);
+  });
+
+  it("returns 1 if B has a wildcard but A doesn't and the lengths are equal", () => {
+    expect(comparePatternKeys('./foo/ab/', './foo/a/*')).toBe(1);
+  });
+
+  it('returns 1 if the actual length of B is longer than the actual length of A', () => {
+    expect(comparePatternKeys('./foo/*/bar', './foo/*/bar/baz')).toBe(1);
+  });
+
+  it('returns 1 if both keys are the same', () => {
+    expect(comparePatternKeys('./foo/', './foo/')).toBe(1);
+  });
+
+  it('returns -1 if the B contains a wildcard', () => {
+    expect(comparePatternKeys('./foo/', './*')).toBe(-1);
+  });
+
+  it('returns -1 if A is longer than B', () => {
+    expect(comparePatternKeys('./foo/*', './*')).toBe(-1);
+  });
+
+  it('returns -1 if A is longer than B without wildcards', () => {
+    expect(comparePatternKeys('./foo/', './')).toBe(-1);
+  });
+
+  it("returns -1 if A has a wildcard but B doesn't and the lengths are equal", () => {
+    expect(comparePatternKeys('./foo/a/*', './foo/ab/')).toBe(-1);
+  });
+
+  it('returns -1 if the actual length of A is longer than the actual length of B', () => {
+    expect(comparePatternKeys('./foo/*/bar/baz', './foo/*/bar')).toBe(-1);
+  });
+
+  it('returns 0 if both keys contain a wildcard and the lengths are equal', () => {
+    expect(comparePatternKeys('./*', './*')).toBe(0);
   });
 });

--- a/packages/resolver/src/resolver.test.ts
+++ b/packages/resolver/src/resolver.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolve } from './resolver.js';
+
+describe('resolve', () => {
+  it('resolves a package', () => {
+    expect(resolve('vite/runtime', import.meta.url)).toStrictEqual({
+      path: expect.stringContaining(
+        'ts-bridge/node_modules/vite/dist/node/runtime.js',
+      ),
+      format: 'module',
+    });
+
+    expect(resolve('typescript', import.meta.url)).toStrictEqual({
+      path: expect.stringContaining(
+        'ts-bridge/node_modules/typescript/lib/typescript.js',
+      ),
+      format: 'commonjs',
+    });
+  });
+});

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -32,6 +32,7 @@ import {
   isObject,
   isPath,
   isRelativeExports,
+  isRoot,
   isURL,
   parseJson,
 } from './utils.js';
@@ -794,7 +795,7 @@ function resolvePackageFromNodeModules(
 ) {
   let parent = fileURLToPath(parentUrl);
 
-  while (parent !== '/') {
+  while (!isRoot(parent)) {
     // 1. Let packageURL be the URL resolution of "node_modules/" concatenated
     // with packageSpecifier, relative to parentURL.
     const packageUrl = resolvePath(parent, 'node_modules', packageSpecifier);
@@ -970,7 +971,7 @@ function getPackageScope(
 
   // 2. While scopeURL is not the file system root,
   // TODO: Check if at file system root on Windows.
-  while (scopeUrl !== '/') {
+  while (!isRoot(scopeUrl)) {
     // 1. Set scopeURL to the parent URL of scopeURL.
     scopeUrl = resolvePath(scopeUrl, '..');
 

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -1,0 +1,1107 @@
+import assert from 'assert';
+import { isBuiltin } from 'module';
+import { resolve as resolvePath, basename, extname } from 'path';
+import { fileURLToPath } from 'url';
+
+import { DEFAULT_CONDITIONS } from './constants.js';
+import {
+  InvalidModuleSpecifierError,
+  InvalidPackageConfigurationError,
+  InvalidPackageTargetError,
+  ModuleNotFoundError,
+  PackageImportNotDefinedError,
+  PackagePathNotExportedError,
+  UnsupportedDirectoryImportError,
+} from './errors.js';
+import type { FileSystemInterface } from './file-system.js';
+import { DEFAULT_FILE_SYSTEM } from './file-system.js';
+import type {
+  FileFormat,
+  PackageExports,
+  PackageExportsObject,
+  PackageJson,
+  Resolution,
+} from './types.js';
+import {
+  getCharacterCount,
+  getDataUrlType,
+  getProtocol,
+  isDefined,
+  isFlagEnabled,
+  isObject,
+  isPath,
+  isRelativeExports,
+  isURL,
+  parseJson,
+} from './utils.js';
+import {
+  isValidPath,
+  validateExportsObject,
+  validatePatternKey,
+} from './validation.js';
+
+/**
+ * Resolve a package specifier to a file path. This is an implementation of the
+ * Node.js module resolution algorithm as defined
+ * [here](https://nodejs.org/api/esm.html#resolution-algorithm-specification).
+ *
+ * In addition to the resolved file path, this function also returns the format
+ * of the module, i.e., whether it is a module, CommonJS, JSON, or WebAssembly
+ * module.
+ *
+ * @param packageSpecifier - The specifier to resolve.
+ * @param parentURL - The URL of the parent module.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved file path and format.
+ * @throws {InvalidModuleSpecifierError} When the module specifier contains
+ * invalid characters.
+ * @throws {UnsupportedDirectoryImportError} When the module specifier is a
+ * directory.
+ */
+export const resolve = getResolver();
+
+/**
+ * Get the resolver function. This is a wrapper of the actual resolution
+ * function, using a cache to store resolved URLs.
+ *
+ * Do not use this function directly. Instead, use the {@link resolve} function.
+ *
+ * @returns The resolver function.
+ */
+function getResolver() {
+  const cache = new Map<string, Resolution>();
+
+  return (
+    packageSpecifier: string,
+    parentUrl: string | URL,
+    fileSystem: FileSystemInterface = DEFAULT_FILE_SYSTEM,
+  ): Resolution => {
+    const cacheKey = `${packageSpecifier}#${fileURLToPath(parentUrl)}`;
+    if (cache.has(cacheKey)) {
+      return cache.get(cacheKey) as Resolution;
+    }
+
+    /**
+     * Resolve the package specifier.
+     *
+     * @returns The resolved package specifier.
+     */
+    function doResolve(): Resolution {
+      const resolvedSpecifier = getResolvedUrl(
+        packageSpecifier,
+        parentUrl,
+        fileSystem,
+      );
+
+      if (
+        // The resolved specifier must not contain encoded slash characters ("/"
+        // or "\").
+        resolvedSpecifier.toLowerCase().includes('%2f') ||
+        resolvedSpecifier.toLowerCase().includes('%5c')
+      ) {
+        throw new InvalidModuleSpecifierError(resolvedSpecifier);
+      }
+
+      const protocol = getProtocol(resolvedSpecifier);
+      switch (protocol) {
+        // https://nodejs.org/api/esm.html#file-urls
+        case 'file:': {
+          const path = fileURLToPath(resolvedSpecifier);
+          if (fileSystem.isDirectory(path)) {
+            throw new UnsupportedDirectoryImportError(resolvedSpecifier);
+          }
+
+          if (!fileSystem.isFile(path)) {
+            throw new ModuleNotFoundError(resolvedSpecifier);
+          }
+
+          const format = getPackageFormat(resolvedSpecifier, fileSystem);
+          return {
+            path,
+            format,
+          };
+        }
+
+        // https://nodejs.org/api/esm.html#node-imports
+        case 'node:': {
+          const path = resolvedSpecifier.slice(5);
+          return {
+            path,
+            format: 'builtin',
+          };
+        }
+
+        // https://nodejs.org/api/esm.html#data-imports
+        case 'data:': {
+          return {
+            path: resolvedSpecifier,
+            format: getDataUrlType(resolvedSpecifier),
+          };
+        }
+
+        default: {
+          return {
+            path: resolvedSpecifier,
+            format: null,
+          };
+        }
+      }
+    }
+
+    const result = doResolve();
+    cache.set(cacheKey, result);
+
+    return result;
+  };
+}
+
+/**
+ * Get the resolved URL for a package specifier.
+ *
+ * @param packageSpecifier - The package specifier to resolve.
+ * @param parentUrl - The URL of the parent module.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved URL.
+ */
+function getResolvedUrl(
+  packageSpecifier: string,
+  parentUrl: string | URL,
+  fileSystem: FileSystemInterface,
+): string {
+  if (isURL(packageSpecifier)) {
+    return new URL(packageSpecifier).href;
+  }
+
+  if (isPath(packageSpecifier)) {
+    return new URL(packageSpecifier, parentUrl).href;
+  }
+
+  if (packageSpecifier.startsWith('#')) {
+    return resolvePackageImports(packageSpecifier, parentUrl, fileSystem);
+  }
+
+  const path = resolvePackage(packageSpecifier, parentUrl, fileSystem);
+  return new URL(path, parentUrl).href;
+}
+
+/**
+ * Get the name of a package from a package specifier.
+ *
+ * @param packageSpecifier - The package specifier to get the name from.
+ * @returns The name of the package.
+ */
+// This is part of the `PACKAGE_RESOLVE` function as defined by the Node.js
+// specification.
+function getPackageName(packageSpecifier: string): string {
+  // 5. Otherwise,
+  if (packageSpecifier.startsWith('@')) {
+    const [scope, name] = packageSpecifier.split('/');
+
+    // 1. If packageSpecifier does not contain a "/" separator, then
+    if (!scope || !name) {
+      // 1. Throw an Invalid Module Specifier error.
+      throw new InvalidModuleSpecifierError(packageSpecifier);
+    }
+
+    // 2. Set packageName to the substring of packageSpecifier until the second
+    // "/" separator or the end of the string.
+    return `${scope}/${name}`;
+  }
+
+  // 4. If packageSpecifier does not start with "@", then
+  const [name] = packageSpecifier.split('/');
+  if (!name) {
+    throw new InvalidModuleSpecifierError(packageSpecifier);
+  }
+
+  // 1. Set packageName to the substring of packageSpecifier until the first "/"
+  //    separator or the end of the string.
+  return name;
+}
+
+/**
+ * Resolve a string package target. This is a helper function used by the
+ * {@link resolvePackageTarget} function.
+ *
+ * @param packageUrl - The URL of the package.
+ * @param target - The target to resolve.
+ * @param patternMatch - The pattern match to use.
+ * @param isImports - Whether the target is an import.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved target.
+ */
+function resolveStringPackageTarget(
+  packageUrl: string,
+  target: string,
+  patternMatch: string | null,
+  isImports: boolean,
+  fileSystem: FileSystemInterface,
+) {
+  // 1. If target does not start with "./", then
+  if (!target.startsWith('./')) {
+    // 1. If isImports is false, or if target starts with "../" or "/", or if
+    // target is a valid URL, then
+    if (
+      !isImports ||
+      target.startsWith('../') ||
+      target.startsWith('/') ||
+      isURL(target)
+    ) {
+      // 1. Throw an Invalid Package Target error.
+      throw new InvalidPackageTargetError(target);
+    }
+
+    // 2. If patternMatch is a String, then
+    if (typeof patternMatch === 'string') {
+      // 1. Return PACKAGE_RESOLVE(target with every instance of "*" replaced
+      // by patternMatch, packageURL + "/").
+      return resolvePackage(
+        target.replaceAll('*', patternMatch),
+        `${packageUrl}/`,
+        fileSystem,
+      );
+    }
+
+    // 3. Return PACKAGE_RESOLVE(target, packageURL + "/").
+    return resolvePackage(target, `${packageUrl}/`, fileSystem);
+  }
+
+  // 2.If target split on "/" or "\" contains any "", ".", "..", or
+  // "node_modules" segments after the first "." segment, case insensitive and
+  // including percent encoded variants, throw an Invalid Package Target
+  // error.
+  // TODO: Validate this slice.
+  if (!isValidPath(target.slice(2))) {
+    throw new InvalidPackageTargetError(target);
+  }
+
+  // 3. Let resolvedTarget be the URL resolution of the concatenation of
+  // packageURL and target.
+  const resolvedTarget = resolvePath(packageUrl, target);
+
+  // 4. Assert: packageURL is contained in resolvedTarget.
+  assert(resolvedTarget.includes(packageUrl));
+
+  // 5.If patternMatch is null, then
+  if (patternMatch === null) {
+    // 1. Return resolvedTarget.
+    return resolvedTarget;
+  }
+
+  // 6. If patternMatch split on "/" or "\" contains any "", ".", "..", or
+  // "node_modules" segments, case insensitive and including percent encoded
+  // variants, throw an Invalid Module Specifier error.
+  if (!isValidPath(patternMatch)) {
+    throw new InvalidModuleSpecifierError(patternMatch);
+  }
+
+  // 7. Return resolvedTarget with every instance of "*" replaced with
+  // patternMatch.
+  return resolvedTarget.replaceAll('*', patternMatch);
+}
+
+/**
+ * Resolve an object package target.
+ *
+ * @param packageUrl - The URL of the package.
+ * @param target - The target to resolve.
+ * @param patternMatch - The pattern match to use.
+ * @param isImports - Whether the target is an import.
+ * @param conditions - The conditions to use. When the target is an object, the
+ * conditions are the keys of the object, which are used to resolve the target.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved target.
+ */
+function resolveObjectPackageTarget(
+  packageUrl: string,
+  target: PackageExportsObject,
+  patternMatch: string | null,
+  isImports: boolean,
+  conditions: string[],
+  fileSystem: FileSystemInterface,
+) {
+  // 1. If target contains any index property keys, as defined in ECMA-262 6.1.7
+  // Array Index, throw an Invalid Package Configuration error.
+  validateExportsObject(packageUrl, target);
+
+  // 2. For each property p of target, in object insertion order as,
+  for (const key of Object.keys(target)) {
+    // 1. If p equals "default" or conditions contains an entry for p, then
+    if (key === 'default' || conditions.includes(key)) {
+      // 1. Let targetValue be the value of the p property in target.
+      const targetValue = target[key] as PackageExports;
+
+      // 2. Let resolved be the result of
+      // PACKAGE_TARGET_RESOLVE( packageURL, targetValue, patternMatch, isImports, conditions).
+      const resolved = resolvePackageTarget(
+        packageUrl,
+        targetValue,
+        patternMatch,
+        isImports,
+        conditions,
+        fileSystem,
+      );
+
+      // 3. If resolved is equal to undefined, continue the loop.
+      if (isDefined(resolved)) {
+        // 4. Return resolved.
+        return resolved;
+      }
+    }
+  }
+
+  // 3. Return undefined.
+  return null;
+}
+
+/**
+ * Resolve an array package target.
+ *
+ * @param packageUrl - The URL of the package.
+ * @param target - The target to resolve.
+ * @param patternMatch - The pattern match to use.
+ * @param isImports - Whether the target is an import.
+ * @param conditions - The conditions to use. When the target is an object, the
+ * conditions are the keys of the object, which are used to resolve the target.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved target.
+ */
+function resolveArrayPackageTarget(
+  packageUrl: string,
+  target: PackageExports[],
+  patternMatch: string | null,
+  isImports: boolean,
+  conditions: string[],
+  fileSystem: FileSystemInterface,
+) {
+  // If the target is an empty array, return null.
+  if (target.length === 0) {
+    return null;
+  }
+
+  /**
+   * Resolve a package target safely, i.e., without throwing an error.
+   *
+   * @param targetValue - The target value to resolve.
+   * @returns The resolved target.
+   */
+  function safeResolvePackageTarget(
+    targetValue: PackageExports,
+  ): [error: unknown | null, result: string | null] {
+    try {
+      const result = resolvePackageTarget(
+        packageUrl,
+        targetValue,
+        patternMatch,
+        isImports,
+        conditions,
+        fileSystem,
+      );
+
+      return [null, result];
+    } catch (error) {
+      return [error, null];
+    }
+  }
+
+  // Each target in the array is resolved in order, and the first
+  // successfully resolved target is returned.
+  for (let index = 0; index < target.length; index++) {
+    const targetValue = target[index] as PackageExports;
+    const [error, resolved] = safeResolvePackageTarget(targetValue);
+    const isLast = index === target.length - 1;
+
+    if (error) {
+      // If the target is not the last target, and the error is an
+      // `InvalidPackageTargetError`, continue to the next target. Otherwise,
+      // throw the error.
+      if (!isLast && error instanceof InvalidPackageTargetError) {
+        continue;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw error;
+    }
+
+    // If the target is successfully resolved, return the resolved target.
+    if (isDefined(resolved)) {
+      return resolved;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a package target, i.e., the target of a package's exports or imports,
+ * based on the given conditions.
+ *
+ * @param packageUrl - The URL of the package.
+ * @param target - The target to resolve.
+ * @param patternMatch - The pattern match to use.
+ * @param isImports - Whether the target is an import.
+ * @param conditions - The conditions to use. When the target is an object, the
+ * conditions are the keys of the object, which are used to resolve the target.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved target.
+ */
+function resolvePackageTarget(
+  packageUrl: string,
+  target: PackageExports | null,
+  patternMatch: string | null,
+  isImports: boolean,
+  conditions: string[],
+  fileSystem: FileSystemInterface,
+): string | null {
+  if (typeof target === 'string') {
+    return resolveStringPackageTarget(
+      packageUrl,
+      target,
+      patternMatch,
+      isImports,
+      fileSystem,
+    );
+  }
+
+  if (isObject(target)) {
+    return resolveObjectPackageTarget(
+      packageUrl,
+      target,
+      patternMatch,
+      isImports,
+      conditions,
+      fileSystem,
+    );
+  }
+
+  if (Array.isArray(target)) {
+    return resolveArrayPackageTarget(
+      packageUrl,
+      target,
+      patternMatch,
+      isImports,
+      conditions,
+      fileSystem,
+    );
+  }
+
+  // 4. Otherwise, if target is null, return null.
+  if (target === null) {
+    // 1. Return null.
+    return null;
+  }
+
+  throw new InvalidPackageTargetError(packageUrl);
+}
+
+/**
+ * Compare two pattern keys and return the comparison result. This can be used
+ * with the `sort` method to sort pattern keys in descending order of
+ * specificity.
+ *
+ * @param a - The first pattern key.
+ * @param b - The second pattern key.
+ * @returns The comparison result, i.e., -1 if `a` is less than `b`, 1 if `a` is
+ * greater than `b`, and 0 if `a` is equal to `b`.
+ */
+function comparePatternKeys(a: string, b: string): number {
+  // 1. Assert: keyA ends with "/" or contains only a single "*".
+  validatePatternKey(a);
+
+  // 2. Assert: keyB ends with "/" or contains only a single "*".
+  validatePatternKey(b);
+
+  // 3. Let baseLengthA be the index of "*" in keyA plus one, if keyA contains
+  // "*", or the length of keyA otherwise.
+  const baseLengthA = a.includes('*') ? a.indexOf('*') + 1 : a.length;
+
+  // 4. Let baseLengthB be the index of "*" in keyB plus one, if keyB contains
+  // "*", or the length of keyB otherwise.
+  const baseLengthB = b.includes('*') ? b.indexOf('*') + 1 : b.length;
+
+  // 5. If baseLengthA is greater than baseLengthB, return -1.
+  if (baseLengthA > baseLengthB) {
+    return -1;
+  }
+
+  // 6. If baseLengthB is greater than baseLengthA, return 1.
+  if (baseLengthB > baseLengthA) {
+    return 1;
+  }
+
+  // 7. If keyA does not contain "*", return 1.
+  if (!a.includes('*')) {
+    return 1;
+  }
+
+  // 8. If keyB does not contain "*", return -1.
+  if (!b.includes('*')) {
+    return -1;
+  }
+
+  // 9. If the length of keyA is greater than the length of keyB, return -1.
+  if (a.length > b.length) {
+    return -1;
+  }
+
+  // 10. If the length of keyB is greater than the length of keyA, return 1.
+  if (b.length > a.length) {
+    return 1;
+  }
+
+  // 11. Return 0.
+  return 0;
+}
+
+/**
+ * Resolve a package's imports or exports.
+ *
+ * @param matchKey - The key to match.
+ * @param matchObject - The object to match against.
+ * @param packageUrl - The URL of the package.
+ * @param isImports - Whether the target is an import.
+ * @param conditions - The conditions to use.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved target.
+ */
+function resolvePackageImportsExports(
+  matchKey: string,
+  matchObject: PackageExportsObject,
+  packageUrl: string,
+  isImports: boolean,
+  conditions: string[],
+  fileSystem: FileSystemInterface,
+): string | null {
+  // 1. If matchKey is a key of matchObj and does not contain "*", then
+  if (matchKey in matchObject && !matchKey.includes('*')) {
+    // 1. Let target be the value of matchObj[matchKey].
+    const target = matchObject[matchKey] as PackageExports;
+
+    // 2. Return the result of PACKAGE_TARGET_RESOLVE(packageURL, target, null, isImports, conditions).
+    return resolvePackageTarget(
+      packageUrl,
+      target,
+      null,
+      isImports,
+      conditions,
+      fileSystem,
+    );
+  }
+
+  // 2. Let expansionKeys be the list of keys of matchObj containing only a single
+  // "*", sorted by the sorting function PATTERN_KEY_COMPARE which orders in
+  // descending order of specificity.
+  const expansionKeys = Object.keys(matchObject)
+    .filter((key) => getCharacterCount(key, '*') === 1)
+    .sort(comparePatternKeys);
+
+  // 3. For each key expansionKey in expansionKeys, do
+  for (const expansionKey of expansionKeys) {
+    // 1. Let patternBase be the substring of expansionKey up to but excluding
+    // the first "*" character.
+    const patternBase = expansionKey.split('*')[0] as string;
+
+    // 2. If matchKey starts with but is not equal to patternBase, then
+    if (matchKey.startsWith(patternBase) && matchKey !== patternBase) {
+      // 1. Let patternTrailer be the substring of expansionKey from the index
+      // after the first "*" character.
+      const patternTrailer = expansionKey.split('*')[1] as string;
+
+      // 2. If patternTrailer has zero length, or if matchKey ends with
+      // patternTrailer and the length of matchKey is greater than or equal to
+      // the length of expansionKey, then
+      if (
+        patternTrailer.length === 0 ||
+        (matchKey.endsWith(patternTrailer) &&
+          matchKey.length >= expansionKey.length)
+      ) {
+        // 1. Let target be the value of matchObj[expansionKey].
+        const target = matchObject[expansionKey] as PackageExports;
+
+        // 2. Let patternMatch be the substring of matchKey starting at the
+        // index of the length of patternBase up to the length of matchKey minus
+        // the length of patternTrailer.
+        const patternMatch = matchKey.slice(
+          patternBase.length,
+          matchKey.length - patternTrailer.length,
+        );
+
+        // 3. Return the result of
+        // PACKAGE_TARGET_RESOLVE(packageURL, target, patternMatch, isImports, conditions).
+        return resolvePackageTarget(
+          packageUrl,
+          target,
+          patternMatch,
+          isImports,
+          conditions,
+          fileSystem,
+        );
+      }
+    }
+  }
+
+  // 4. Return null.
+  return null;
+}
+
+/**
+ * Resolve a package's exports. This checks the `exports` field of a package's
+ * `package.json` file, and resolves the target of the package.
+ *
+ * @param packageUrl - The URL of the package.
+ * @param packageSubpath - The subpath of the package to resolve.
+ * @param exports - The exports object to resolve.
+ * @param conditions - The conditions to use.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved target.
+ */
+function resolvePackageExports(
+  packageUrl: string,
+  packageSubpath: string,
+  exports: PackageExports,
+  conditions: string[],
+  fileSystem: FileSystemInterface,
+) {
+  // If exports is an Object with both a key starting with "." and a key not
+  // starting with ".", throw an Invalid Package Configuration error.
+  if (isObject(exports)) {
+    validateExportsObject(packageUrl, exports);
+  }
+
+  if (packageSubpath === '.') {
+    let mainExport;
+    if (
+      typeof exports === 'string' ||
+      Array.isArray(exports) ||
+      !isRelativeExports(exports)
+    ) {
+      mainExport = exports;
+    }
+
+    if (isRelativeExports(exports)) {
+      mainExport = exports['.'];
+    }
+
+    if (mainExport) {
+      const resolved = resolvePackageTarget(
+        packageUrl,
+        mainExport,
+        null,
+        false,
+        conditions,
+        fileSystem,
+      );
+
+      if (isDefined(resolved)) {
+        return resolved;
+      }
+    }
+  }
+
+  if (isRelativeExports(exports)) {
+    assert(packageSubpath.startsWith('./'));
+    const resolved = resolvePackageImportsExports(
+      packageSubpath,
+      exports,
+      packageUrl,
+      false,
+      conditions,
+      fileSystem,
+    );
+
+    if (isDefined(resolved)) {
+      return resolved;
+    }
+  }
+
+  throw new PackagePathNotExportedError(packageSubpath);
+}
+
+/**
+ * Resolve a package from the current package.
+ *
+ * @param packageName - The name of the package to resolve.
+ * @param packageSubpath - The subpath of the package to resolve.
+ * @param parentUrl - The URL of the parent module.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved URL.
+ */
+function resolveSelf(
+  packageName: string,
+  packageSubpath: string,
+  parentUrl: string | URL,
+  fileSystem: FileSystemInterface,
+): string | null {
+  // 1. Let packageURL be the result of LOOKUP_PACKAGE_SCOPE(parentURL).
+  const packageUrl = getPackageScope(parentUrl, fileSystem);
+
+  // 2. If packageURL is null, then
+  if (packageUrl === null) {
+    // 1. Return undefined.
+    return null;
+  }
+
+  const packageJson = getPackageJson(packageUrl, fileSystem);
+
+  // 4. If pjson is null or if pjson.exports is null or undefined, then
+  if (packageJson === null || !packageJson.exports) {
+    // 1. Return undefined
+    return null;
+  }
+
+  // 5. If pjson.name is equal to packageName, then
+  if (packageName === packageJson.name) {
+    // 5.1. Return the result of
+    //      PACKAGE_EXPORTS_RESOLVE(packageURL, packageSubpath, pjson.exports, defaultConditions).
+    return resolvePackageExports(
+      packageUrl,
+      packageSubpath,
+      packageJson.exports,
+      DEFAULT_CONDITIONS,
+      fileSystem,
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a package from the `node_modules` directory.
+ *
+ * This checks the current directory and all parent directories for the
+ * `node_modules` directory.
+ *
+ * @param packageSpecifier - The package specifier to resolve.
+ * @param packageSubpath - The subpath of the package to resolve.
+ * @param parentUrl - The URL of the parent module.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved URL.
+ */
+export function resolvePackageFromNodeModules(
+  packageSpecifier: string,
+  packageSubpath: string,
+  parentUrl: string | URL,
+  fileSystem: FileSystemInterface,
+) {
+  let parent = fileURLToPath(parentUrl);
+
+  while (parent !== '/') {
+    // 1. Let packageURL be the URL resolution of "node_modules/" concatenated
+    // with packageSpecifier, relative to parentURL.
+    const packageUrl = resolvePath(parent, 'node_modules', packageSpecifier);
+
+    if (fileSystem.isDirectory(packageUrl)) {
+      const packageJson = getPackageJson(packageUrl, fileSystem);
+      if (packageJson) {
+        // 1. If pjson is not null and pjson.exports is not null or undefined,
+        // then
+        if (packageJson.exports) {
+          // 1. Return the result of
+          // `PACKAGE_EXPORTS_RESOLVE(packageURL, packageSubpath, pjson.exports, defaultConditions).`
+          return resolvePackageExports(
+            packageUrl,
+            packageSubpath,
+            packageJson.exports,
+            DEFAULT_CONDITIONS,
+            fileSystem,
+          );
+        }
+
+        if (packageJson.main) {
+          return resolvePath(packageUrl, packageJson.main);
+        }
+
+        return resolvePath(packageUrl, packageSubpath);
+      }
+    }
+
+    // 2. Set parentURL to the parent folder URL of parentURL.
+    parent = resolvePath(parent, '..');
+  }
+
+  throw new ModuleNotFoundError(packageSpecifier);
+}
+
+/**
+ * Resolve an external package specifier.
+ *
+ * @param packageSpecifier - The package specifier to resolve.
+ * @param parentUrl - The URL of the parent module.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved URL.
+ */
+function resolvePackage(
+  packageSpecifier: string,
+  parentUrl: string | URL,
+  fileSystem: FileSystemInterface,
+): string {
+  // 2. If packageSpecifier is an empty string, then
+  if (packageSpecifier === '') {
+    // 1. Throw an Invalid Module Specifier error.
+    throw new InvalidModuleSpecifierError(packageSpecifier);
+  }
+
+  if (isBuiltin(packageSpecifier)) {
+    return `node:${packageSpecifier}`;
+  }
+
+  const packageName = getPackageName(packageSpecifier);
+
+  // 6. If packageName starts with "." or contains "\" or "%", then
+  if (
+    packageName.startsWith('.') ||
+    packageName.includes('\\') ||
+    packageName.includes('%')
+  ) {
+    // 1. Throw an Invalid Module Specifier error.
+    throw new InvalidModuleSpecifierError(packageSpecifier);
+  }
+
+  // 7. Let packageSubpath be "." concatenated with the substring of
+  // packageSpecifier from the position at the length of packageName.
+  const packageSubpath = `.${packageSpecifier.slice(packageName.length)}`;
+
+  // 8. If packageSubpath ends in "/", then
+  if (packageSubpath.endsWith('/')) {
+    // 1. Throw an Invalid Module Specifier error.
+    throw new InvalidModuleSpecifierError(packageSpecifier);
+  }
+
+  // 9. Let selfUrl be the result of PACKAGE_SELF_RESOLVE(packageName, packageSubpath, parentURL).
+  const selfUrl = resolveSelf(
+    packageName,
+    packageSubpath,
+    parentUrl,
+    fileSystem,
+  );
+
+  // 10. If selfUrl is not undefined, return selfUrl.
+  if (isDefined(selfUrl)) {
+    return selfUrl;
+  }
+
+  // 11. While parentURL is not the file system root,
+  return resolvePackageFromNodeModules(
+    packageName,
+    packageSubpath,
+    parentUrl,
+    fileSystem,
+  );
+}
+
+/**
+ * Resolve a package import, i.e., a package specifier that starts with `#`.
+ *
+ * @param packageSpecifier - The package specifier to resolve.
+ * @param parentUrl - The URL of the parent module.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved URL.
+ */
+function resolvePackageImports(
+  packageSpecifier: string,
+  parentUrl: string | URL,
+  fileSystem: FileSystemInterface,
+): string {
+  // 1. Assert: specifier begins with "#".
+  assert(packageSpecifier.startsWith('#'));
+
+  // 2. If specifier is exactly equal to "#" or starts with "#/", then
+  if (packageSpecifier === '#' || packageSpecifier.startsWith('#/')) {
+    // 1. Throw an Invalid Module Specifier error.
+    throw new InvalidModuleSpecifierError(packageSpecifier);
+  }
+
+  // 3. Let packageURL be the result of LOOKUP_PACKAGE_SCOPE(parentURL).
+  const packageUrl = getPackageScope(parentUrl, fileSystem);
+
+  // 4. If packageURL is not null, then
+  if (isDefined(packageUrl)) {
+    // 1. Let pjson be the result of READ_PACKAGE_JSON(packageURL).
+    const packageJson = getPackageJson(packageUrl, fileSystem);
+
+    // 2. If pjson.imports is a non-null Object, then
+    if (isObject(packageJson?.imports)) {
+      // 1. Let resolved be the result of
+      // PACKAGE_IMPORTS_EXPORTS_RESOLVE( specifier, pjson.imports, packageURL, true, conditions).
+      const resolved = resolvePackageImportsExports(
+        packageSpecifier,
+        packageJson.imports,
+        packageUrl,
+        true,
+        DEFAULT_CONDITIONS,
+        fileSystem,
+      );
+
+      // 2. If resolved is not null or undefined, return resolved.
+      if (isDefined(resolved)) {
+        return resolved;
+      }
+    }
+  }
+
+  // 5. Throw a Package Import Not Defined error.
+  throw new PackageImportNotDefinedError(packageSpecifier);
+}
+
+/**
+ * Get the scope of a package, i.e., the directory containing the `package.json`
+ * file.
+ *
+ * @param resolvedSpecifier - The resolved URL of the package. See
+ * {@link getResolvedUrl}.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The scope of the package.
+ */
+function getPackageScope(
+  resolvedSpecifier: string | URL,
+  fileSystem: FileSystemInterface,
+): string | null {
+  // 1. Let scopeURL be url.
+  let scopeUrl = fileURLToPath(resolvedSpecifier);
+
+  // 2. While scopeURL is not the file system root,
+  // TODO: Check if at file system root on Windows.
+  while (scopeUrl !== '/') {
+    // 1. Set scopeURL to the parent URL of scopeURL.
+    scopeUrl = resolvePath(scopeUrl, '..');
+
+    // 2. If scopeURL ends in a "node_modules" path segment, return null.
+    const lastSegment = basename(scopeUrl);
+    if (lastSegment === 'node_modules') {
+      return null;
+    }
+
+    // 3. Let pjsonURL be the resolution of "package.json" within scopeURL.
+    const packageJsonUrl = resolvePath(scopeUrl, 'package.json');
+    if (fileSystem.isFile(packageJsonUrl)) {
+      return scopeUrl;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the `package.json` file for a given package URL.
+ *
+ * @param packageUrl - The URL of the package.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The `package.json` file.
+ */
+function getPackageJson(
+  packageUrl: string | null,
+  fileSystem: FileSystemInterface,
+): PackageJson | null {
+  if (!packageUrl) {
+    return null;
+  }
+
+  const packageJsonUrl = resolvePath(packageUrl, 'package.json');
+  const packageJsonValue = fileSystem.readFile(packageJsonUrl);
+  const packageJson = parseJson<PackageJson>(packageJsonValue);
+
+  if (packageJson === null) {
+    throw new InvalidPackageConfigurationError(packageUrl);
+  }
+
+  return packageJson;
+}
+
+/**
+ * Get the format of a package for a given URL.
+ *
+ * @param resolvedSpecifier - The resolved URL of the package. See
+ * {@link getResolvedUrl}.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The format of the package.
+ */
+function getPackageFormat(
+  resolvedSpecifier: string,
+  fileSystem: FileSystemInterface,
+): FileFormat | null {
+  // 1. Assert: url corresponds to an existing file.
+  const path = fileURLToPath(resolvedSpecifier);
+  assert(fileSystem.isFile(path));
+
+  // 2. If url ends in ".mjs", then
+  //    1. Return "module".
+  if (resolvedSpecifier.endsWith('.mjs')) {
+    return 'module';
+  }
+
+  // 3. If url ends in ".cjs", then
+  //    1. Return "commonjs".
+  if (resolvedSpecifier.endsWith('.cjs')) {
+    return 'commonjs';
+  }
+
+  // 4. If url ends in ".json", then
+  //    1. Return "json".
+  if (resolvedSpecifier.endsWith('.json')) {
+    return 'json';
+  }
+
+  // 5. If `--experimental-wasm-modules` is enabled and url ends in ".wasm", then
+  //    1. Return "wasm".
+  if (
+    isFlagEnabled('--experimental-wasm-modules') &&
+    resolvedSpecifier.endsWith('.wasm')
+  ) {
+    return 'wasm';
+  }
+
+  // 6. Let packageURL be the result of LOOKUP_PACKAGE_SCOPE(url).
+  const packageUrl = getPackageScope(resolvedSpecifier, fileSystem);
+
+  // 7. Let pjson be the result of READ_PACKAGE_JSON(packageURL).
+  const packageJson = getPackageJson(packageUrl, fileSystem);
+
+  if (resolvedSpecifier.endsWith('.js')) {
+    if (packageJson?.type) {
+      return packageJson.type;
+    }
+
+    // 2. If --experimental-detect-module is enabled and the result of
+    //    DETECT_MODULE_SYNTAX(source) is true, then
+    // eslint-disable-next-line no-constant-condition
+    if (isFlagEnabled('--experimental-detect-module')) {
+      // TODO: Experimental module detection.
+    }
+
+    return 'commonjs';
+  }
+
+  // 11. If url does not have any extension, then
+  if (extname(resolvedSpecifier) === '') {
+    // 1. If packageType is "module" and --experimental-wasm-modules is enabled
+    // and the file at url contains the header for a WebAssembly module, then
+    if (isFlagEnabled('--experimental-wasm-modules')) {
+      const content = fileSystem.readBytes(path, 4);
+
+      // WASM_BINARY_MAGIC = 0x0061736d
+      if (
+        content[0] === 0x00 &&
+        content[1] === 0x61 &&
+        content[2] === 0x73 &&
+        content[3] === 0x6d
+      ) {
+        // 1. Return "wasm".
+        return 'wasm';
+      }
+    }
+
+    // 2. If packageType is not null, then
+    if (packageJson?.type) {
+      // Return packageType.
+      return packageJson.type;
+    }
+
+    // 3. If --experimental-detect-module is enabled and the result of
+    //    DETECT_MODULE_SYNTAX(source) is true, then
+    if (isFlagEnabled('--experimental-detect-module')) {
+      // TODO: Experimental module detection.
+    }
+  }
+
+  return null;
+}

--- a/packages/resolver/src/types.ts
+++ b/packages/resolver/src/types.ts
@@ -1,0 +1,82 @@
+/**
+ * An object containing the exports for a package, i.e., the `exports` field in
+ * a `package.json`.
+ *
+ * The keys are the names of the exports, and the values are the paths to the
+ * files that the exports point to, or an object containing the exports for
+ * certain conditions.
+ */
+export type PackageExportsObject = Record<
+  string,
+  string | Record<string, string>
+>;
+
+/**
+ * The exports for a package, i.e., the `exports` field in a `package.json`.
+ */
+export type PackageExports = string | string[] | PackageExportsObject;
+
+/**
+ * An object containing the imports for a package, i.e., the `imports` field in
+ * a `package.json`.
+ *
+ * The keys are the names of the imports, and the values are the paths to the
+ * files that the imports point to.
+ */
+export type PackageImports = Record<string, string>;
+
+/**
+ * A (partial) `package.json` file. This type is used to represent the contents
+ * of a `package.json` file, and is used to extract the information needed to
+ * resolve imports.
+ *
+ * It does not contain all the fields of a `package.json` file, only the fields
+ * that are relevant for resolving imports.
+ */
+export type PackageJson = {
+  /**
+   * The name of the package.
+   */
+  name?: string;
+
+  /**
+   * The type of the package.
+   */
+  type?: 'commonjs' | 'module';
+
+  /**
+   * The main entry point of the package. This is unused if `exports` is
+   * present.
+   */
+  main?: string;
+
+  /**
+   * The exports of the package.
+   */
+  exports?: PackageExports;
+
+  /**
+   * The imports of the package.
+   */
+  imports?: PackageImports;
+};
+
+/**
+ * The supported file formats for resolving imports.
+ */
+export type FileFormat = 'module' | 'commonjs' | 'json' | 'wasm' | 'builtin';
+
+/**
+ * The resolution of an import.
+ */
+export type Resolution = {
+  /**
+   * The absolute path to the resolved file.
+   */
+  path: string;
+
+  /**
+   * The format of the resolved file, or `null` if the format is unknown.
+   */
+  format: FileFormat | null;
+};

--- a/packages/resolver/src/utils.test.ts
+++ b/packages/resolver/src/utils.test.ts
@@ -10,6 +10,7 @@ import {
   isObject,
   isPath,
   isRelativeExports,
+  isRoot,
   isURL,
   parseJson,
 } from './utils.js';
@@ -168,4 +169,20 @@ describe('getDataUrlType', () => {
       'Module specifier is an invalid URL, package name or package subpath specifier: "data:application/unknown,...".',
     );
   });
+});
+
+describe('isRoot', () => {
+  it.each(['/', 'C:\\', 'C:/', 'D:\\', 'D:/', '\\\\'])(
+    'returns `true` for "%s"',
+    (path) => {
+      expect(isRoot(path)).toBe(true);
+    },
+  );
+
+  it.each(['/foo', '/bar', 'C', 'D', 'C:\\example', 'D:/example', '\\\\path'])(
+    'returns `false` for "%s"',
+    (path) => {
+      expect(isRoot(path)).toBe(false);
+    },
+  );
 });

--- a/packages/resolver/src/utils.test.ts
+++ b/packages/resolver/src/utils.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getCharacterCount,
+  getDataUrlMimeType,
+  getDataUrlType,
+  getProtocol,
+  isDefined,
+  isFlagEnabled,
+  isObject,
+  isPath,
+  isRelativeExports,
+  isURL,
+  parseJson,
+} from './utils.js';
+
+describe('isURL', () => {
+  it.each([
+    'http://example.com',
+    'https://example.com',
+    'file:///example.com',
+    'data:text/javascript,console.log("Hello, world!")',
+    'data:application/json,{"hello":"world"}',
+  ])('returns true for "%s"', (url) => {
+    expect(isURL(url)).toBe(true);
+  });
+
+  it.each(['example.com', 'example'])('returns false for "%s"', (url) => {
+    expect(isURL(url)).toBe(false);
+  });
+});
+
+describe('getProtocol', () => {
+  it.each([
+    ['http:', 'http://example.com'],
+    ['https:', 'https://example.com'],
+    ['file:', 'file:///example.com'],
+    ['data:', 'data:text/javascript,console.log("Hello, world!")'],
+  ])('returns "%s" for "%s"', (protocol, url) => {
+    expect(getProtocol(url)).toBe(protocol);
+  });
+});
+
+describe('isPath', () => {
+  it.each(['/example', './example', '../example'])(
+    'returns true for "%s"',
+    (path) => {
+      expect(isPath(path)).toBe(true);
+    },
+  );
+
+  it.each(['example.com', 'example'])('returns false for "%s"', (path) => {
+    expect(isPath(path)).toBe(false);
+  });
+});
+
+describe('parseJson', () => {
+  it('parses JSON', () => {
+    expect(parseJson('{"hello":"world"}')).toStrictEqual({ hello: 'world' });
+  });
+
+  it('returns `null` for invalid JSON', () => {
+    expect(parseJson('hello')).toBe(null);
+  });
+});
+
+describe('isObject', () => {
+  it.each([{ hello: 'world' }, {}])('returns `true` for `%o`', (value) => {
+    expect(isObject(value)).toBe(true);
+  });
+
+  it.each([null, undefined, 0, 'hello', ['hello']])(
+    'returns `false` for `%o`',
+    (value) => {
+      expect(isObject(value)).toBe(false);
+    },
+  );
+});
+
+describe('isRelativeExports', () => {
+  it('returns true if all keys in an object are relative', () => {
+    expect(isRelativeExports({ './foo': 'bar', './baz/qux': 'quux' })).toBe(
+      true,
+    );
+  });
+
+  it('returns false if any key in an object is not relative', () => {
+    expect(isRelativeExports({ './foo': 'bar', baz: 'qux' })).toBe(false);
+  });
+});
+
+describe('isDefined', () => {
+  it.each([
+    [false, null],
+    [false, undefined],
+    [true, 0],
+    [true, ''],
+  ])('returns `%s` for `%o`', (expected, value) => {
+    expect(isDefined(value)).toBe(expected);
+  });
+});
+
+describe('getCharacterCount', () => {
+  it('returns the number of characters in a string', () => {
+    expect(getCharacterCount('hello', 'l')).toBe(2);
+  });
+
+  it('returns 0 if the character is not found', () => {
+    expect(getCharacterCount('hello', 'z')).toBe(0);
+  });
+
+  it('supports special characters', () => {
+    expect(getCharacterCount('hello, world!', ',')).toBe(1);
+  });
+});
+
+describe('isFlagEnabled', () => {
+  it('returns true if the flag is enabled', () => {
+    expect(
+      isFlagEnabled('--experimental-wasm-modules', [
+        '--experimental-wasm-modules',
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns false if the flag is disabled', () => {
+    expect(isFlagEnabled('--experimental-wasm-modules', [])).toBe(false);
+  });
+
+  it('returns false if the flag is not set', () => {
+    expect(isFlagEnabled('--experimental-wasm-modules')).toBe(false);
+  });
+});
+
+describe('getDataUrlMimeType', () => {
+  it.each([
+    ['text/javascript', 'data:text/javascript,console.log("Hello, world!")'],
+    ['application/json', 'data:application/json,{"hello":"world"}'],
+    ['application/wasm', 'data:application/wasm,base64,...'],
+  ])('returns "%s" for "%s"', (mimeType, url) => {
+    expect(getDataUrlMimeType(url)).toBe(mimeType);
+  });
+
+  it('throws an error if the MIME type is not found', () => {
+    expect(() => getDataUrlMimeType('data:')).toThrow(
+      'Module specifier is an invalid URL, package name or package subpath specifier: "data:".',
+    );
+  });
+});
+
+describe('getDataUrlType', () => {
+  it.each([
+    ['module', 'data:text/javascript,console.log("Hello, world!")'],
+    ['json', 'data:application/json,{"hello":"world"}'],
+    ['wasm', 'data:application/wasm,base64,...'],
+  ])('returns "%s" for "%s"', (mimeType, url) => {
+    expect(getDataUrlType(url)).toBe(mimeType);
+  });
+
+  it('throws an error if the MIME type is not found', () => {
+    expect(() => getDataUrlType('data:')).toThrow(
+      'Module specifier is an invalid URL, package name or package subpath specifier: "data:".',
+    );
+  });
+
+  it('throws an error if the MIME type is not supported', () => {
+    expect(() => getDataUrlType('data:application/unknown,...')).toThrow(
+      'Module specifier is an invalid URL, package name or package subpath specifier: "data:application/unknown,...".',
+    );
+  });
+});

--- a/packages/resolver/src/utils.ts
+++ b/packages/resolver/src/utils.ts
@@ -1,3 +1,6 @@
+import { parse as parsePosix } from 'path/posix';
+import { parse as parseWin32 } from 'path/win32';
+
 import { InvalidModuleSpecifierError } from './errors.js';
 import type {
   FileFormat,
@@ -168,4 +171,37 @@ export function getDataUrlType(url: string): FileFormat {
     default:
       throw new InvalidModuleSpecifierError(url);
   }
+}
+
+/**
+ * Check if a path is a Windows root path, such as `C:\` or `\\`.
+ *
+ * @param path - The path to check.
+ * @returns `true` if the path is a Windows root path, `false` otherwise.
+ */
+function isWindowsRoot(path: string): boolean {
+  // TODO: Verify behaviour for network paths.
+  const { root, dir, base } = parseWin32(path);
+  return root === dir && base === '';
+}
+
+/**
+ * Check if a path is a POSIX root path, such as `/`.
+ *
+ * @param path - The path to check.
+ * @returns `true` if the path is a POSIX root path, `false` otherwise.
+ */
+function isPosixRoot(path: string): boolean {
+  const { root, dir, base } = parsePosix(path);
+  return root === dir && base === '';
+}
+
+/**
+ * Check if a path is the root path, with support for Unix and Windows paths.
+ *
+ * @param path - The path to check.
+ * @returns `true` if the path is the root path, `false` otherwise.
+ */
+export function isRoot(path: string): boolean {
+  return isPosixRoot(path) || isWindowsRoot(path);
 }

--- a/packages/resolver/src/utils.ts
+++ b/packages/resolver/src/utils.ts
@@ -18,7 +18,7 @@ export function isURL(url: string): boolean {
 /**
  * Get the protocol for a URL string.
  *
- * @param url - The URL string.
+ * @param url - The URL string. This function assumes that this URL is valid.
  * @returns The protocol for the URL string.
  */
 export function getProtocol(url: string): string {
@@ -62,7 +62,8 @@ export function isObject(
 }
 
 /**
- * Check if the given exports object is a relative exports object.
+ * Check if the given exports object is a relative exports object, i.e., it
+ * contains keys that start with a dot.
  *
  * @param exports - The exports object to check.
  * @returns `true` if the exports object is a relative exports object, `false`
@@ -88,37 +89,6 @@ export function isDefined<Type>(value: Type | null | undefined): value is Type {
 }
 
 /**
- * Check if the given target is a valid target for a package.
- *
- * @param target - The target to check.
- * @returns `true` if the target is valid, `false` otherwise.
- */
-export function isValidTarget(target: string) {
-  const lowerCaseTarget = target.toLowerCase();
-
-  /**
-   * Check if the given array is a valid target for a package.
-   *
-   * @param targetArray - The array to check.
-   * @returns `true` if the array is a valid target, `false` otherwise.
-   */
-  function isValid(targetArray: string[]) {
-    // TODO: Check percent encoded variants of these characters.
-    return (
-      !targetArray.includes('') &&
-      !targetArray.includes('.') &&
-      !targetArray.includes('..') &&
-      !targetArray.includes('node_modules')
-    );
-  }
-
-  return (
-    isValid(lowerCaseTarget.split('/').slice(1)) &&
-    isValid(lowerCaseTarget.split('\\').slice(1))
-  );
-}
-
-/**
  * Get the number of occurrences of a character in a string.
  *
  * @param value - The string to search.
@@ -133,12 +103,15 @@ export function getCharacterCount(value: string, character: string): number {
  * Check if the given flag is enabled in the current process.
  *
  * @param flag - The flag to check.
+ * @param execArgv - The `process.execArgv` array to check. This is useful for
+ * testing.
  * @returns `true` if the flag is enabled, `false` otherwise.
  */
 export function isFlagEnabled(
   flag: '--experimental-detect-module' | '--experimental-wasm-modules',
+  execArgv = process.execArgv,
 ): boolean {
-  return process.execArgv.includes(flag);
+  return execArgv.includes(flag);
 }
 
 /**
@@ -181,6 +154,7 @@ export function getDataUrlMimeType(url: string): string {
  * @returns The file format of the data URL.
  * @throws {InvalidModuleSpecifierError} If the data URL is not valid or
  * unsupported.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
  */
 export function getDataUrlType(url: string): FileFormat {
   const mimeType = getDataUrlMimeType(url);

--- a/packages/resolver/src/utils.ts
+++ b/packages/resolver/src/utils.ts
@@ -1,0 +1,197 @@
+import { InvalidModuleSpecifierError } from './errors.js';
+import type {
+  FileFormat,
+  PackageExports,
+  PackageExportsObject,
+} from './types.js';
+
+/**
+ * Check if the given string is a valid URL.
+ *
+ * @param url - The string to check.
+ * @returns `true` if the string is a valid URL, `false` otherwise.
+ */
+export function isURL(url: string): boolean {
+  return URL.canParse(url);
+}
+
+/**
+ * Get the protocol for a URL string.
+ *
+ * @param url - The URL string.
+ * @returns The protocol for the URL string.
+ */
+export function getProtocol(url: string): string {
+  return new URL(url).protocol;
+}
+
+/**
+ * Check if the given string is a path, starting with `/`, `./`, or `../`.
+ *
+ * @param url - The string to check.
+ * @returns `true` if the string is a path, `false` otherwise.
+ */
+export function isPath(url: string): boolean {
+  return url.startsWith('/') || url.startsWith('./') || url.startsWith('../');
+}
+
+/**
+ * Try to parse a string value as JSON.
+ *
+ * @param value - The value to try to parse.
+ * @returns The parsed JSON value, or `null` if the value is not valid JSON.
+ */
+export function parseJson<Type>(value: string): Type | null {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a value is an object (and not an array or `null`).
+ *
+ * @param value - The value to check.
+ * @returns `true` if the value is an object, `false` otherwise.
+ */
+export function isObject(
+  value: unknown,
+): value is Record<PropertyKey, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Check if the given exports object is a relative exports object.
+ *
+ * @param exports - The exports object to check.
+ * @returns `true` if the exports object is a relative exports object, `false`
+ * otherwise.
+ */
+export function isRelativeExports(
+  exports: PackageExports,
+): exports is PackageExportsObject {
+  return (
+    isObject(exports) &&
+    Object.keys(exports).every((key) => key.startsWith('.'))
+  );
+}
+
+/**
+ * Check if the given value is defined (not `null` or `undefined`).
+ *
+ * @param value - The value to check.
+ * @returns `true` if the value is defined, `false` otherwise.
+ */
+export function isDefined<Type>(value: Type | null | undefined): value is Type {
+  return value !== null && value !== undefined;
+}
+
+/**
+ * Check if the given target is a valid target for a package.
+ *
+ * @param target - The target to check.
+ * @returns `true` if the target is valid, `false` otherwise.
+ */
+export function isValidTarget(target: string) {
+  const lowerCaseTarget = target.toLowerCase();
+
+  /**
+   * Check if the given array is a valid target for a package.
+   *
+   * @param targetArray - The array to check.
+   * @returns `true` if the array is a valid target, `false` otherwise.
+   */
+  function isValid(targetArray: string[]) {
+    // TODO: Check percent encoded variants of these characters.
+    return (
+      !targetArray.includes('') &&
+      !targetArray.includes('.') &&
+      !targetArray.includes('..') &&
+      !targetArray.includes('node_modules')
+    );
+  }
+
+  return (
+    isValid(lowerCaseTarget.split('/').slice(1)) &&
+    isValid(lowerCaseTarget.split('\\').slice(1))
+  );
+}
+
+/**
+ * Get the number of occurrences of a character in a string.
+ *
+ * @param value - The string to search.
+ * @param character - The character to search for.
+ * @returns The number of occurrences of the character in the string.
+ */
+export function getCharacterCount(value: string, character: string): number {
+  return value.split(character).length - 1;
+}
+
+/**
+ * Check if the given flag is enabled in the current process.
+ *
+ * @param flag - The flag to check.
+ * @returns `true` if the flag is enabled, `false` otherwise.
+ */
+export function isFlagEnabled(
+  flag: '--experimental-detect-module' | '--experimental-wasm-modules',
+): boolean {
+  return process.execArgv.includes(flag);
+}
+
+/**
+ * Get the MIME type of a data URL. Node.js supports several types of `data:`
+ * URLs, such as:
+ *
+ * - `data:text/javascript,console.log('Hello, world!');` for ES modules.
+ * - `data:application/json,{"hello":"world"}` for JSON modules.
+ * - `data:application/wasm;base64,...` for WebAssembly modules.
+ *
+ * This function returns the MIME type of the data URL, such as
+ * `text/javascript`, `application/json`, or `application/wasm`.
+ *
+ * @param url - The data URL.
+ * @returns The MIME type of the data URL.
+ * @throws {InvalidModuleSpecifierError} If the data URL is not valid or
+ * unsupported.
+ */
+export function getDataUrlMimeType(url: string): string {
+  const mimeType = url.split(':')[1]?.split(',')[0];
+  if (!mimeType) {
+    throw new InvalidModuleSpecifierError(url);
+  }
+
+  return mimeType;
+}
+
+/**
+ * Get the file format of a data URL. Node.js supports several types of `data:`
+ * URLs, such as:
+ *
+ * - `data:text/javascript,console.log('Hello, world!');` for ES modules.
+ * - `data:application/json,{"hello":"world"}` for JSON modules.
+ * - `data:application/wasm;base64,...` for WebAssembly modules.
+ *
+ * This function returns the file format of the data URL, such as `module`,
+ * `json`, or `wasm`.
+ *
+ * @param url - The data URL.
+ * @returns The file format of the data URL.
+ * @throws {InvalidModuleSpecifierError} If the data URL is not valid or
+ * unsupported.
+ */
+export function getDataUrlType(url: string): FileFormat {
+  const mimeType = getDataUrlMimeType(url);
+  switch (mimeType) {
+    case 'text/javascript':
+      return 'module';
+    case 'application/json':
+      return 'json';
+    case 'application/wasm':
+      return 'wasm';
+    default:
+      throw new InvalidModuleSpecifierError(url);
+  }
+}

--- a/packages/resolver/src/validation.test.ts
+++ b/packages/resolver/src/validation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isValidPath,
+  isValidPathSegments,
+  validateExportsObject,
+  validatePatternKey,
+} from './validation.js';
+
+describe('isValidPathSegments', () => {
+  it('returns `true` for an array without any invalid segments', () => {
+    expect(isValidPathSegments(['foo', 'bar'])).toBe(true);
+  });
+
+  it.each(['.', '..', 'node_modules', ''])(
+    'returns `false` for an array containing "%s"',
+    (segment) => {
+      expect(isValidPathSegments(['foo', segment])).toBe(false);
+    },
+  );
+});
+
+describe('isValidPath', () => {
+  it('returns `true` for a path without any invalid segments', () => {
+    expect(isValidPath('foo/bar')).toBe(true);
+  });
+
+  it('returns `true` for a path with backslashes', () => {
+    expect(isValidPath('foo\\bar')).toBe(true);
+  });
+
+  it.each(['./foo', '../foo', 'node_modules', ''])(
+    'returns `false` for a path containing "%s"',
+    (segment) => {
+      expect(isValidPath(`foo/${segment}`)).toBe(false);
+    },
+  );
+
+  it.each(['./foo', '../foo', 'node_modules', ''])(
+    'returns `false` for a path containing "%s" with backslashes',
+    (segment) => {
+      expect(isValidPath(`foo\\${segment}`)).toBe(false);
+    },
+  );
+
+  it('is case-insensitive', () => {
+    expect(isValidPath('foo/NODE_MODULES')).toBe(false);
+  });
+});
+
+describe('validateExportsObject', () => {
+  it('does not throw an error for an object with only relative keys', () => {
+    expect(() =>
+      validateExportsObject('file:///foo/package.json', {
+        './foo': 'bar',
+        './baz/qux': 'quux',
+      }),
+    ).not.toThrow();
+  });
+
+  it('does not throw an error for an object with only non-relative keys', () => {
+    expect(() =>
+      validateExportsObject('file:///foo/package.json', {
+        foo: 'bar',
+        baz: 'qux',
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws an error for an object with a mix of relative and non-relative keys', () => {
+    expect(() =>
+      validateExportsObject('file:///foo/package.json', {
+        './foo': 'bar',
+        baz: 'qux',
+      }),
+    ).toThrow(
+      '`package.json` configuration is invalid or contains an invalid configuration: "file:///foo/package.json".',
+    );
+  });
+
+  it('throws an error for an object containing valid array index keys', () => {
+    expect(() =>
+      validateExportsObject('file:///foo/package.json', {
+        '0': 'bar',
+        '1': 'qux',
+      }),
+    ).toThrow(
+      '`package.json` configuration is invalid or contains an invalid configuration: "file:///foo/package.json".',
+    );
+  });
+});
+
+describe('validatePatternKey', () => {
+  it('does not throw an error for a valid pattern key', () => {
+    expect(() => validatePatternKey('./foo/')).not.toThrow();
+    expect(() => validatePatternKey('./foo/*')).not.toThrow();
+  });
+
+  it('throws an error for an invalid pattern key', () => {
+    expect(() => validatePatternKey('./foo')).toThrow();
+  });
+});

--- a/packages/resolver/src/validation.ts
+++ b/packages/resolver/src/validation.ts
@@ -1,0 +1,87 @@
+import assert from 'assert';
+
+import { InvalidPackageConfigurationError } from './errors.js';
+import type { PackageExportsObject } from './types.js';
+import { getCharacterCount } from './utils.js';
+
+/**
+ * Check if a set of path segments is valid, i.e. it does not contain empty
+ * segments, dot segments, parent segments, or `node_modules` segments.
+ *
+ * @param pathSegments - The path segments to validate.
+ * @returns `true` if the path segments are valid, `false` otherwise.
+ */
+export function isValidPathSegments(pathSegments: string[]): boolean {
+  return (
+    !pathSegments.includes('') &&
+    !pathSegments.includes('.') &&
+    !pathSegments.includes('..') &&
+    !pathSegments.includes('node_modules')
+  );
+}
+
+/**
+ * Check if a path is valid, i.e. it does not contain empty segments, dot
+ * segments, parent segments, or `node_modules` segments.
+ *
+ * @param path - The path to validate.
+ * @returns `true` if the path is valid, `false` otherwise.
+ */
+export function isValidPath(path: string): boolean {
+  const lowerCasePath = path.toLowerCase();
+
+  return (
+    isValidPathSegments(lowerCasePath.split('/')) &&
+    isValidPathSegments(lowerCasePath.split('\\'))
+  );
+}
+
+/**
+ * Validate the exports object of a package, ensuring that it does not contain
+ * a mix of keys that start with a dot and keys that do not start with a dot.
+ *
+ * @param packageUrl - The URL of the package being validated.
+ * @param exports - The exports object to validate.
+ * @throws {InvalidPackageConfigurationError} If the exports object contains a
+ * mix of keys that start with a dot and keys that do not start with a dot.
+ */
+export function validateExportsObject(
+  packageUrl: string,
+  exports: PackageExportsObject,
+) {
+  const keys = Object.keys(exports);
+
+  let startsWithDot = false;
+  let startsWithoutDot = false;
+
+  for (const key of keys) {
+    if (key.startsWith('.')) {
+      startsWithDot = true;
+    } else {
+      startsWithoutDot = true;
+    }
+
+    if (startsWithDot && startsWithoutDot) {
+      throw new InvalidPackageConfigurationError(packageUrl);
+    }
+
+    // If target contains any index property keys, as defined in ECMA-262 6.1.7
+    // Array Index, throw an Invalid Package Configuration error.
+    // This step is done later in the spec, but we do it here to avoid
+    // unnecessary iteration.
+    if (!Number.isNaN(parseInt(key, 10))) {
+      throw new InvalidPackageConfigurationError(packageUrl);
+    }
+  }
+}
+
+/**
+ * Validate a pattern key, ensuring that it ends with a slash or contains a
+ * single asterisk character.
+ *
+ * @param key - The pattern key to validate.
+ * @throws {AssertionError} If the pattern key is invalid.
+ */
+export function validatePatternKey(key: string) {
+  assert(key.endsWith('/') || getCharacterCount(key, '*') === 1);
+}

--- a/packages/resolver/src/validation.ts
+++ b/packages/resolver/src/validation.ts
@@ -30,10 +30,7 @@ export function isValidPathSegments(pathSegments: string[]): boolean {
 export function isValidPath(path: string): boolean {
   const lowerCasePath = path.toLowerCase();
 
-  return (
-    isValidPathSegments(lowerCasePath.split('/')) &&
-    isValidPathSegments(lowerCasePath.split('\\'))
-  );
+  return isValidPathSegments(lowerCasePath.split(/[\\/]/u));
 }
 
 /**

--- a/packages/resolver/tsconfig.build.json
+++ b/packages/resolver/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": ".tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/packages/resolver/tsconfig.build.json
+++ b/packages/resolver/tsconfig.build.json
@@ -7,5 +7,10 @@
     "rootDir": "./src",
     "tsBuildInfoFile": ".tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../test-utils/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/resolver/tsconfig.json
+++ b/packages/resolver/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "./"
+  },
+  "exclude": ["./dist", "./node_modules"]
+}

--- a/packages/resolver/tsconfig.json
+++ b/packages/resolver/tsconfig.json
@@ -4,5 +4,10 @@
     "baseUrl": "./",
     "rootDir": "./"
   },
-  "exclude": ["./dist", "./node_modules"]
+  "exclude": ["./dist", "./node_modules"],
+  "references": [
+    {
+      "path": "../test-utils"
+    }
+  ]
 }

--- a/packages/resolver/vitest.config.mts
+++ b/packages/resolver/vitest.config.mts
@@ -1,0 +1,9 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    watch: false,
+  },
+});

--- a/packages/test-utils/src/file-system.ts
+++ b/packages/test-utils/src/file-system.ts
@@ -1,0 +1,101 @@
+import { resolve as resolvePath } from 'path';
+import { fileURLToPath } from 'url';
+
+type FileEntry = {
+  type: 'file';
+  content: string | Uint8Array;
+};
+
+type DirectoryEntry = {
+  type: 'directory';
+};
+
+export type Entry = FileEntry | DirectoryEntry;
+
+/**
+ * The options for the virtual file system. The key is the path to the file or
+ * directory, and the value is the content of the file, or object representing
+ * the directory.
+ */
+export type FileSystemOptions = Record<string, string | Uint8Array | Entry>;
+
+/**
+ * Get a basic virtual read-only file system for testing purposes. It does not
+ * support writing to the file system.
+ *
+ * @param options - The options for the virtual file system.
+ * @returns The virtual file system.
+ */
+export function getFileSystem(options: FileSystemOptions = {}) {
+  const entries: [string, Entry][] = Object.entries(options).map(
+    ([path, value]) => {
+      if (typeof value === 'string') {
+        return [path, { type: 'file', content: value }];
+      }
+
+      if (value instanceof Uint8Array) {
+        return [path, { type: 'file', content: value }];
+      }
+
+      return [path, value];
+    },
+  );
+
+  const fileSystem = new Map<string, Entry>(entries);
+  const fileSystemInterface = {
+    readRawFile: (path: string) => {
+      const entry = fileSystem.get(path);
+      if (!entry) {
+        throw new Error(`File not found: ${path}`);
+      }
+
+      if (entry.type === 'directory') {
+        throw new Error(`Cannot read directory: ${path}`);
+      }
+
+      return entry.content;
+    },
+
+    isDirectory: (path: string) => {
+      const entry = fileSystem.get(path);
+      return entry?.type === 'directory';
+    },
+
+    isFile: (path: string) => {
+      const entry = fileSystem.get(path);
+      return entry?.type === 'file';
+    },
+
+    readFile: (path: string) => {
+      const entry = fileSystemInterface.readRawFile(path);
+      if (typeof entry === 'string') {
+        return entry;
+      }
+
+      return new TextDecoder().decode(entry);
+    },
+
+    readBytes: (path: string, length: number) => {
+      const content = fileSystemInterface.readRawFile(path);
+      if (typeof content === 'string') {
+        return new TextEncoder().encode(content).slice(0, length);
+      }
+
+      return content.slice(0, length);
+    },
+  };
+
+  return fileSystemInterface;
+}
+
+const ROOT_PATH = resolvePath(fileURLToPath(import.meta.url), '../../../..');
+
+/**
+ * Get an absolute path from the root of the project.
+ *
+ * @param path - The path relative to the root of the project.
+ * @returns The absolute path.
+ */
+export function getPathFromRoot(path: string): string {
+  return resolvePath(ROOT_PATH, path);
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,3 +1,4 @@
 export * from './evaluate.js';
 export * from './virtual-environment.js';
 export * from './mocks.js';
+export * from './file-system.js';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,9 +5,6 @@
       "path": "./packages/cli/tsconfig.build.json"
     },
     {
-      "path": "./packages/helpers/tsconfig.build.json"
-    },
-    {
       "path": "./packages/resolver/tsconfig.build.json"
     },
     {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,6 +5,12 @@
       "path": "./packages/cli/tsconfig.build.json"
     },
     {
+      "path": "./packages/helpers/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/resolver/tsconfig.build.json"
+    },
+    {
       "path": "./packages/shims/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,6 @@
       "path": "./packages/cli"
     },
     {
-      "path": "./packages/helpers"
-    },
-    {
       "path": "./packages/resolver"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,12 @@
       "path": "./packages/cli"
     },
     {
+      "path": "./packages/helpers"
+    },
+    {
+      "path": "./packages/resolver"
+    },
+    {
       "path": "./packages/shims"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,6 +1110,7 @@ __metadata:
   resolution: "@ts-bridge/resolver@workspace:packages/resolver"
   dependencies:
     "@metamask/auto-changelog": "npm:^3.4.4"
+    "@ts-bridge/test-utils": "workspace:^"
     typescript: "npm:^5.4.5"
     vite-tsconfig-paths: "npm:^4.3.2"
     vitest: "npm:^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,6 +1105,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ts-bridge/resolver@workspace:packages/resolver":
+  version: 0.0.0-use.local
+  resolution: "@ts-bridge/resolver@workspace:packages/resolver"
+  dependencies:
+    "@metamask/auto-changelog": "npm:^3.4.4"
+    typescript: "npm:^5.4.5"
+    vite-tsconfig-paths: "npm:^4.3.2"
+    vitest: "npm:^1.5.0"
+  languageName: unknown
+  linkType: soft
+
 "@ts-bridge/root@workspace:.":
   version: 0.0.0-use.local
   resolution: "@ts-bridge/root@workspace:."


### PR DESCRIPTION
This adds a new package, which is an implementation of Node.js' module resolution algorithm. This can be used by the TS Bridge CLI to detect if a module resolves, and whether it is CommonJS, ESM, or something else.

The aim of this package is to 100% match the implementation of Node.js.