### PR TITLE
Don't modify JSON (or other non-JS) imports/exports

### DIFF
--- a/packages/cli/src/generator.test.ts
+++ b/packages/cli/src/generator.test.ts
@@ -85,6 +85,21 @@ describe('getImportPath', () => {
     ).toBe('module');
   });
 
+  it('returns the import path for a non-JS file as is', () => {
+    expect(
+      getImportPath(
+        {
+          fileName: '/index.ts',
+          importPath: './file.json',
+          compilerOptions: program.getCompilerOptions(),
+          extension: '.js',
+          baseDirectory: '/',
+        },
+        system,
+      ),
+    ).toBe('./file.json');
+  });
+
   it('returns the import path for an unresolved module as is', () => {
     expect(
       getImportPath(

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { isBuiltin } from 'module';
-import { dirname, relative, resolve } from 'path';
+import { dirname, extname, relative, resolve } from 'path';
 import type {
   CompilerOptions,
   TypeChecker,
@@ -34,6 +34,8 @@ const {
   SymbolFlags,
   SyntaxKind,
 } = typescript;
+
+const JS_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts'];
 
 /**
  * The options for the `getImportPath` function.
@@ -74,6 +76,16 @@ export function getImportPath(options: GetImportPathOptions, system: System) {
   } = options;
 
   if (isBuiltin(importPath)) {
+    return importPath;
+  }
+
+  // Only update the extension if the resolved file has a `.js` or similar
+  // extension, or no extension. This is to prevent updating the extension for
+  // non-JS files (like `.json` files).
+  if (
+    extname(importPath) !== '' &&
+    !JS_EXTENSIONS.includes(extname(importPath))
+  ) {
     return importPath;
   }
 


### PR DESCRIPTION
Closes #22.

Previously, TS Bridge would modify `.json` and other non-JS imports/exports to `.json.cjs` or `.json.mjs`. This adds a check to only modify files that have a `.js`-like file extension originally, or don't have an extension.

This will be more permanently solved when we implement `@ts-bridge/resolver`, as it can detect the type of files (i.e., CommonJS, ES Module, JSON, or something else).