### PR TITLE
Add experimental support for project references

### DIFF
--- a/packages/cli/src/build-type.test.ts
+++ b/packages/cli/src/build-type.test.ts
@@ -11,6 +11,7 @@ describe('getBuildTypeOptions', () => {
         "getShimsTransformers": [Function],
         "getTransformers": [Function],
         "name": "ES module",
+        "sourceExtension": ".mts",
         "target": 99,
       }
     `);
@@ -24,6 +25,7 @@ describe('getBuildTypeOptions', () => {
         "getShimsTransformers": [Function],
         "getTransformers": [Function],
         "name": "CommonJS module",
+        "sourceExtension": ".cts",
         "target": 1,
       }
     `);

--- a/packages/cli/src/build-type.ts
+++ b/packages/cli/src/build-type.ts
@@ -42,6 +42,7 @@ export type BuildTypeOptions = {
   name: string;
   extension: string;
   declarationExtension: string;
+  sourceExtension: string;
   target: ResolutionMode;
   getTransformers: (
     options: TransformerOptions,
@@ -56,6 +57,7 @@ export const BUILD_TYPES: Record<BuildType, BuildTypeOptions> = {
     name: 'ES module',
     extension: '.mjs',
     declarationExtension: '.d.mts',
+    sourceExtension: '.mts',
     target: ModuleKind.ESNext,
     getTransformers: (options) => [
       getNamedImportTransformer(options),
@@ -77,6 +79,7 @@ export const BUILD_TYPES: Record<BuildType, BuildTypeOptions> = {
     name: 'CommonJS module',
     extension: '.cjs',
     declarationExtension: '.d.cts',
+    sourceExtension: '.cts',
     target: ModuleKind.CommonJS,
     getTransformers: (options) => [
       getRemoveImportAttributeTransformer(options),

--- a/packages/cli/src/build.test.ts
+++ b/packages/cli/src/build.test.ts
@@ -40,8 +40,13 @@ function compile(
 
   const system: System = {
     ...sys,
-    writeFile(path: string, data: string) {
+    writeFile(
+      path: string,
+      data: string,
+      writeByteOrderMark?: boolean | undefined,
+    ) {
       files[relative(projectPath, path)] = data;
+      sys.writeFile(path, data, writeByteOrderMark);
     },
   };
 
@@ -348,6 +353,46 @@ describe('build', () => {
           'dist/index.d.cts',
         ]);
       });
+    });
+  });
+
+  describe('project references', () => {
+    let files: Record<string, string>;
+
+    beforeAll(() => {
+      files = compile(
+        getFixture('project-references'),
+        ['commonjs', 'module'],
+        {
+          references: true,
+        },
+      );
+    });
+
+    it('builds all projects when using project references', () => {
+      expect(Object.keys(files)).toStrictEqual([
+        'packages/project-3/dist/index.mjs',
+        'packages/project-3/dist/index.d.mts.map',
+        'packages/project-3/dist/index.d.mts',
+        'packages/project-3/tsconfig.tsbuildinfo',
+        'packages/project-3/dist/index.cjs',
+        'packages/project-3/dist/index.d.cts.map',
+        'packages/project-3/dist/index.d.cts',
+        'packages/project-1/dist/index.mjs',
+        'packages/project-1/dist/index.d.mts.map',
+        'packages/project-1/dist/index.d.mts',
+        'packages/project-1/tsconfig.tsbuildinfo',
+        'packages/project-1/dist/index.cjs',
+        'packages/project-1/dist/index.d.cts.map',
+        'packages/project-1/dist/index.d.cts',
+        'packages/project-2/dist/index.mjs',
+        'packages/project-2/dist/index.d.mts.map',
+        'packages/project-2/dist/index.d.mts',
+        'packages/project-2/tsconfig.tsbuildinfo',
+        'packages/project-2/dist/index.cjs',
+        'packages/project-2/dist/index.d.cts.map',
+        'packages/project-2/dist/index.d.cts',
+      ]);
     });
   });
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -318,17 +318,20 @@ export function buildNode16({
  * @param options.program - The base TypeScript program to use.
  * @param options.format - The formats to build.
  * @param options.system - The file system to use.
+ * @param options.baseDirectory - The base directory of the project.
  */
 export function buildProjectReferences({
   program,
   format,
   system,
+  baseDirectory,
 }: BuilderOptions) {
   const resolvedProjectReferences = getDefinedArray(
     program.getResolvedProjectReferences(),
   );
 
   const sortedProjectReferences = getResolvedProjectReferences(
+    baseDirectory,
     resolvedProjectReferences,
   );
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -350,6 +350,7 @@ export function buildProjectReferences({
 
     const compilerOptions = getCompilerOptions(baseChildOptions);
     const host = createProjectReferencesCompilerHost(
+      format,
       compilerOptions,
       getDefinedArray(references),
     );

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -2,7 +2,9 @@ import { dirname, join } from 'path';
 import type {
   CompilerHost,
   CompilerOptions,
+  ParsedCommandLine,
   Program,
+  ProjectReference,
   System,
 } from 'typescript';
 import typescript from 'typescript';
@@ -18,6 +20,10 @@ import {
 import { TypeScriptError } from './errors.js';
 import { getWriteFileFunction, removeDirectory } from './file-system.js';
 import { getLoggingTransformer } from './logging.js';
+import {
+  createProjectReferencesCompilerHost,
+  getResolvedProjectReferences,
+} from './project-references.js';
 import { isShimsPackageInstalled } from './shims.js';
 import type { Steps } from './steps.js';
 import { executeSteps } from './steps.js';
@@ -28,12 +34,14 @@ import {
   getImportExtensionTransformer,
   getRequireExtensionTransformer,
 } from './transformers.js';
+import { getDefinedArray } from './utils.js';
 
 const { createProgram, getPreEmitDiagnostics, ModuleResolutionKind } =
   typescript;
 
 type GetProgramOptions = {
   compilerOptions: CompilerOptions;
+  projectReferences?: readonly ProjectReference[];
   files: string[];
   oldProgram?: Program;
   host?: CompilerHost;
@@ -46,6 +54,7 @@ type GetProgramOptions = {
  *
  * @param options - The options.
  * @param options.compilerOptions - The compiler options to use.
+ * @param options.projectReferences - The project references to use.
  * @param options.files - The files to include in the program.
  * @param options.oldProgram - The old program to reuse.
  * @param options.host - The compiler host to use.
@@ -53,6 +62,7 @@ type GetProgramOptions = {
  */
 export function getProgram({
   compilerOptions,
+  projectReferences,
   files,
   oldProgram,
   host,
@@ -60,6 +70,7 @@ export function getProgram({
   const program = createProgram({
     rootNames: files,
     options: compilerOptions,
+    projectReferences,
     oldProgram,
     host,
   });
@@ -113,6 +124,7 @@ export type BuildHandlerOptions = {
   system: System;
   host?: CompilerHost;
   verbose?: boolean;
+  references?: boolean;
 };
 
 /**
@@ -129,6 +141,7 @@ export function buildHandler(options: BuildHandlerOptions) {
     system,
     host,
     verbose,
+    references,
   } = options;
 
   const tsConfig = getTypeScriptConfig(project, system);
@@ -145,33 +158,30 @@ export function buildHandler(options: BuildHandlerOptions) {
   const files = getFiles(customFiles, tsConfig.fileNames);
 
   const compilerOptions = getCompilerOptions(baseOptions);
-  const program = getProgram({ compilerOptions, files, host });
+  const program = getProgram({
+    compilerOptions,
+    files,
+    host,
+    projectReferences: tsConfig.projectReferences,
+  });
 
-  if (
-    compilerOptions.moduleResolution !== ModuleResolutionKind.Node16 &&
-    compilerOptions.moduleResolution !== ModuleResolutionKind.NodeNext
-  ) {
-    // If we use a module resolution other than `Node16` (or `NodeNext`), we
-    // need to create a separate program for each module format. This is
-    // unfortunately much slower than using the same program for all formats, so
-    // it's recommended to use `Node16` (or `NodeNext`) if possible.
-    buildNode10({
-      program,
-      compilerOptions,
-      format,
-      files,
-      system,
-      host,
-      baseDirectory,
-      verbose,
-    });
-    return;
-  }
+  const buildOptions: BuilderOptions = {
+    program,
+    compilerOptions,
+    format,
+    files,
+    system,
+    host,
+    baseDirectory,
+    tsConfig,
+    verbose,
+  };
 
-  buildNode16(program, format, system);
+  const buildFunction = getBuildFunction(tsConfig, references);
+  buildFunction(buildOptions);
 }
 
-type BuildNode10Options = {
+type BuilderOptions = {
   program: Program;
   compilerOptions: CompilerOptions;
   format: string[];
@@ -179,6 +189,7 @@ type BuildNode10Options = {
   system: System;
   host?: CompilerHost;
   baseDirectory: string;
+  tsConfig: ParsedCommandLine;
   verbose?: boolean;
 };
 
@@ -205,7 +216,7 @@ export function buildNode10({
   system,
   host,
   verbose,
-}: BuildNode10Options) {
+}: BuilderOptions) {
   const buildSteps: Steps<Record<string, never>> = [
     {
       name: 'Building ES module.',
@@ -267,28 +278,29 @@ export function buildNode10({
 /**
  * Build the project using the Node.js 16 module resolution strategy.
  *
- * @param program - The TypeScript program to build.
- * @param formats - The formats to build.
- * @param system - The file system to use.
- * @param verbose - Whether to enable verbose logging.
+ * @param options - The build options.
+ * @param options.program - The TypeScript program to build.
+ * @param options.format - The formats to build.
+ * @param options.system - The file system to use.
+ * @param options.verbose - Whether to enable verbose logging.
  */
-export function buildNode16(
-  program: Program,
-  formats: string[],
-  system: System,
-  verbose?: boolean,
-) {
+export function buildNode16({
+  program,
+  format,
+  system,
+  verbose,
+}: BuilderOptions) {
   const buildSteps: Steps<Record<string, never>> = [
     {
       name: 'Building ES module.',
-      condition: () => formats.includes('module'),
+      condition: () => format.includes('module'),
       task: () => {
         build({ program, type: 'module', system });
       },
     },
     {
       name: 'Building CommonJS module.',
-      condition: () => formats.includes('commonjs'),
+      condition: () => format.includes('commonjs'),
       task: () => {
         build({ program, type: 'commonjs', system });
       },
@@ -296,6 +308,99 @@ export function buildNode16(
   ];
 
   executeSteps(buildSteps, {}, verbose);
+}
+
+/**
+ * Build the project references. This function will build the project references
+ * using the specified formats.
+ *
+ * @param options - The build options.
+ * @param options.program - The base TypeScript program to use.
+ * @param options.format - The formats to build.
+ * @param options.system - The file system to use.
+ */
+export function buildProjectReferences({
+  program,
+  format,
+  system,
+}: BuilderOptions) {
+  const resolvedProjectReferences = getDefinedArray(
+    program.getResolvedProjectReferences(),
+  );
+
+  const sortedProjectReferences = getResolvedProjectReferences(
+    resolvedProjectReferences,
+  );
+
+  for (const {
+    sourceFile,
+    commandLine,
+    references,
+  } of sortedProjectReferences) {
+    const {
+      fileNames,
+      options: childOptions,
+      projectReferences: childProjectReferences,
+    } = commandLine;
+
+    const baseChildOptions = getBaseCompilerOptions(
+      dirname(sourceFile.fileName),
+      childOptions,
+    );
+
+    const compilerOptions = getCompilerOptions(baseChildOptions);
+    const host = createProjectReferencesCompilerHost(
+      compilerOptions,
+      getDefinedArray(references),
+    );
+
+    const childProgram = getProgram({
+      compilerOptions,
+      host,
+      projectReferences: childProjectReferences,
+      files: fileNames,
+      oldProgram: program,
+    });
+
+    const buildFunction = getBuildFunction(commandLine);
+    buildFunction({
+      host,
+      program: childProgram,
+      compilerOptions,
+      format,
+      files: fileNames,
+      system,
+      baseDirectory: dirname(sourceFile.fileName),
+      tsConfig: commandLine,
+    });
+  }
+}
+
+/**
+ * Get the build function to use based on the TypeScript configuration. This
+ * function will return the appropriate build function based on whether project
+ * references are used and the module resolution strategy.
+ *
+ * @param tsConfig - The TypeScript configuration.
+ * @param useReferences - Whether to include project references in the build.
+ * @returns The build function to use.
+ */
+export function getBuildFunction(
+  tsConfig: ParsedCommandLine,
+  useReferences = false,
+): (options: BuilderOptions) => void {
+  if (useReferences && tsConfig.projectReferences) {
+    return buildProjectReferences;
+  }
+
+  if (
+    tsConfig.options.moduleResolution !== ModuleResolutionKind.Node16 &&
+    tsConfig.options.moduleResolution !== ModuleResolutionKind.NodeNext
+  ) {
+    return buildNode10;
+  }
+
+  return buildNode16;
 }
 
 /**

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -117,7 +117,7 @@ export function getFiles(
  * @property clean - Whether to clean the output directory before building.
  */
 export type BuildHandlerOptions = {
-  format: string[];
+  format: BuildType[];
   project: string;
   files?: string[];
   clean: boolean;
@@ -184,7 +184,7 @@ export function buildHandler(options: BuildHandlerOptions) {
 type BuilderOptions = {
   program: Program;
   compilerOptions: CompilerOptions;
-  format: string[];
+  format: BuildType[];
   files: string[];
   system: System;
   host?: CompilerHost;

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -37,6 +37,7 @@ describe('cli', () => {
       '--formats',
       'commonjs',
       '--clean',
+      '--references',
     ]);
 
     expect(buildHandler).toHaveBeenCalledWith(
@@ -44,6 +45,7 @@ describe('cli', () => {
         clean: true,
         formats: ['module', 'commonjs'],
         project: resolve(process.cwd(), './tsconfig.json'),
+        references: true,
       }),
     );
   });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,6 +3,7 @@ import typescript from 'typescript';
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
 
+import type { BuildType } from './build-type.js';
 import { buildHandler } from './build.js';
 import { error } from './logging.js';
 
@@ -57,8 +58,9 @@ export async function main(argv: string[]) {
               'Build project references in the project. Enabled by default if `tsconfig.json` contains project references.',
             default: true,
           }),
-      (options) => {
+      ({ format, ...options }) => {
         return buildHandler({
+          format: format as BuildType[],
           ...options,
           system: sys,
         });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -48,14 +48,15 @@ export async function main(argv: string[]) {
             type: 'boolean',
             description: 'Enable verbose logging.',
             default: false,
+          })
+          .option('references', {
+            // `tsc` uses `--build`.
+            alias: ['build'],
+            type: 'boolean',
+            description:
+              'Build project references in the project. Enabled by default if `tsconfig.json` contains project references.',
+            default: true,
           }),
-      // .positional('files', {
-      //   type: 'string',
-      //   description:
-      //     'The files to build. Defaults to the files in the `tsconfig.json`.',
-      //   array: true,
-      //   demandOption: false,
-      // }),
       (options) => {
         return buildHandler({
           ...options,

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -36,7 +36,7 @@ describe('getTypeScriptConfig', () => {
     expect(getTypeScriptConfig('/tsconfig.json', system).options)
       .toMatchInlineSnapshot(`
         {
-          "configFilePath": undefined,
+          "configFilePath": "/tsconfig.json",
           "declaration": true,
           "declarationDir": "/",
           "declarationMap": true,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -46,6 +46,8 @@ export function getTypeScriptConfig(path: string, system = sys) {
     config,
     system,
     dirname(path),
+    undefined,
+    path,
   );
 
   if (parsedConfig.errors.length) {

--- a/packages/cli/src/project-references.test.ts
+++ b/packages/cli/src/project-references.test.ts
@@ -189,7 +189,7 @@ describe('createProjectReferencesCompilerHost', () => {
     });
   });
 
-  it('returns a compiler host object with a modified `getSourceFile` method', () => {
+  it('modifies the source file to `.cts` when building `commonjs`', () => {
     const host = createProjectReferencesCompilerHost(
       ['commonjs'],
       tsConfig.options,

--- a/packages/cli/src/project-references.test.ts
+++ b/packages/cli/src/project-references.test.ts
@@ -158,7 +158,8 @@ describe('getResolvedProjectReferences', () => {
         getFixture('project-references'),
         references,
       ),
-    ).toThrow(`Unable to build project references due to a dependency cycle:
+    )
+      .toThrow(`Unable to build project references due to one or more dependency cycles:
 - packages/project-1/tsconfig.circular.json -> packages/project-3/tsconfig.circular.json -> packages/project-2/tsconfig.circular.json -> packages/project-1/tsconfig.circular.json`);
   });
 });

--- a/packages/cli/src/project-references.test.ts
+++ b/packages/cli/src/project-references.test.ts
@@ -181,8 +181,9 @@ describe('createProjectReferencesCompilerHost', () => {
     });
   });
 
-  it('returns a compiler host object with a modified getSourceFile method', () => {
+  it('returns a compiler host object with a modified `getSourceFile` method', () => {
     const host = createProjectReferencesCompilerHost(
+      ['commonjs'],
       tsConfig.options,
       getDefinedArray(program.getResolvedProjectReferences()),
     );
@@ -198,8 +199,27 @@ describe('createProjectReferencesCompilerHost', () => {
     );
   });
 
+  it('modifies the source file to `.mts` when building `module`', () => {
+    const host = createProjectReferencesCompilerHost(
+      ['module'],
+      tsConfig.options,
+      getDefinedArray(program.getResolvedProjectReferences()),
+    );
+
+    const sourceFile = host.getSourceFile(
+      getFixture('project-references', 'packages/project-1/dist/index.d.ts'),
+      ScriptTarget.ES2020,
+    );
+
+    expect(sourceFile).toBeDefined();
+    expect(sourceFile?.fileName).toContain(
+      'packages/project-1/dist/index.d.mts',
+    );
+  });
+
   it('does not modify the source file for non-output files', () => {
     const host = createProjectReferencesCompilerHost(
+      ['commonjs'],
       tsConfig.options,
       getDefinedArray(program.getResolvedProjectReferences()),
     );

--- a/packages/cli/src/project-references.test.ts
+++ b/packages/cli/src/project-references.test.ts
@@ -1,0 +1,215 @@
+import { getFixture, getRelativePath } from '@ts-bridge/test-utils';
+import { dirname } from 'path';
+import type { Program, ResolvedProjectReference } from 'typescript';
+import { ScriptTarget, sys } from 'typescript';
+import { fileURLToPath } from 'url';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { buildProjectReferences, getProgram } from './build.js';
+import { getTypeScriptConfig } from './config.js';
+import type { DependencyGraph } from './project-references.js';
+import {
+  createGraph,
+  createProjectReferencesCompilerHost,
+  getResolvedProjectReferences,
+  topologicalSort,
+} from './project-references.js';
+import { getDefinedArray } from './utils.js';
+
+/**
+ * Get the compact name of a resolved project reference.
+ *
+ * @param name - The full name of the resolved project reference.
+ * @returns The compact name of the resolved project reference.
+ */
+function getReferenceName(name: string) {
+  return getRelativePath('project-references', dirname(name));
+}
+
+/**
+ * Simplify an array of resolved project references for ease of testing.
+ *
+ * @param array - The array of resolved project references to simplify.
+ * @returns The array with string values.
+ */
+function simplifyArray(array: ResolvedProjectReference[]) {
+  return array.map((reference) =>
+    getReferenceName(reference.sourceFile.fileName),
+  );
+}
+
+/**
+ * Simplify a dependency graph for ease of testing.
+ *
+ * @param graph - The dependency graph to simplify.
+ * @returns The dependency graph with string keys and values.
+ */
+function simplifyGraph(graph: DependencyGraph<ResolvedProjectReference>) {
+  const map = new Map<string, string[]>();
+
+  for (const [key, value] of graph) {
+    map.set(getReferenceName(key.sourceFile.fileName), simplifyArray(value));
+  }
+
+  return map;
+}
+
+describe('createGraph', () => {
+  it('creates a dependency graph', () => {
+    const { options, projectReferences, fileNames } = getTypeScriptConfig(
+      getFixture('project-references', 'tsconfig.json'),
+    );
+
+    const program = getProgram({
+      compilerOptions: options,
+      files: fileNames,
+      projectReferences,
+    });
+
+    const references = getDefinedArray(program.getResolvedProjectReferences());
+    const graph = createGraph(references);
+
+    expect(simplifyGraph(graph)).toMatchInlineSnapshot(`
+      Map {
+        "packages/project-1" => [
+          "packages/project-3",
+        ],
+        "packages/project-2" => [
+          "packages/project-1",
+        ],
+        "packages/project-3" => [],
+      }
+    `);
+  });
+});
+
+describe('topologicalSort', () => {
+  it('topologically sorts a dependency graph', () => {
+    const graph: DependencyGraph<string> = new Map([
+      ['a', ['b', 'd']],
+      ['b', ['c', 'e']],
+      ['c', ['d']],
+      ['d', ['e']],
+      ['e', []],
+    ]);
+
+    const { stack, cycle } = topologicalSort(graph);
+    expect(stack).toStrictEqual(['e', 'd', 'c', 'b', 'a']);
+    expect(cycle).toBe(false);
+  });
+
+  it('detects a cycle in a dependency graph', () => {
+    const graph: DependencyGraph<string> = new Map([
+      ['a', ['b', 'd']],
+      ['b', ['c', 'e']],
+      ['c', ['d']],
+      ['d', ['e']],
+      ['e', ['a']],
+    ]);
+
+    const { stack, cycle } = topologicalSort(graph);
+    expect(stack).toStrictEqual(['e', 'd', 'c', 'b', 'a']);
+    expect(cycle).toBe(true);
+  });
+});
+
+describe('getResolvedProjectReferences', () => {
+  it('gets the resolved project references', () => {
+    const { options, projectReferences, fileNames } = getTypeScriptConfig(
+      getFixture('project-references', 'tsconfig.json'),
+    );
+
+    const program = getProgram({
+      compilerOptions: options,
+      files: fileNames,
+      projectReferences,
+    });
+
+    const references = getDefinedArray(program.getResolvedProjectReferences());
+    const resolvedProjectReferences = getResolvedProjectReferences(
+      references,
+    ).map((reference) => getReferenceName(reference.sourceFile.fileName));
+
+    expect(resolvedProjectReferences).toStrictEqual([
+      'packages/project-3',
+      'packages/project-1',
+      'packages/project-2',
+    ]);
+  });
+
+  it('throws an error if a project reference is circular', () => {
+    const { options, projectReferences, fileNames } = getTypeScriptConfig(
+      getFixture('project-references', 'tsconfig.circular.json'),
+    );
+
+    const program = getProgram({
+      compilerOptions: options,
+      files: fileNames,
+      projectReferences,
+    });
+
+    const references = getDefinedArray(program.getResolvedProjectReferences());
+    expect(() => getResolvedProjectReferences(references)).toThrow(
+      'Unable to build project references due to a dependency cycle.',
+    );
+  });
+});
+
+describe('createProjectReferencesCompilerHost', () => {
+  let program: Program;
+  const tsConfig = getTypeScriptConfig(
+    getFixture('project-references', 'tsconfig.json'),
+  );
+
+  beforeAll(() => {
+    program = getProgram({
+      compilerOptions: tsConfig.options,
+      files: tsConfig.fileNames,
+      projectReferences: tsConfig.projectReferences,
+    });
+
+    // To test the modified `getSourceFile` method, the project references need
+    // to be built.
+    buildProjectReferences({
+      program,
+      tsConfig,
+      compilerOptions: tsConfig.options,
+      files: tsConfig.fileNames,
+      format: ['commonjs'],
+      baseDirectory: getFixture('project-references'),
+      system: sys,
+    });
+  });
+
+  it('returns a compiler host object with a modified getSourceFile method', () => {
+    const host = createProjectReferencesCompilerHost(
+      tsConfig.options,
+      getDefinedArray(program.getResolvedProjectReferences()),
+    );
+
+    const sourceFile = host.getSourceFile(
+      getFixture('project-references', 'packages/project-1/dist/index.d.ts'),
+      ScriptTarget.ES2020,
+    );
+
+    expect(sourceFile).toBeDefined();
+    expect(sourceFile?.fileName).toContain(
+      'packages/project-1/dist/index.d.cts',
+    );
+  });
+
+  it('does not modify the source file for non-output files', () => {
+    const host = createProjectReferencesCompilerHost(
+      tsConfig.options,
+      getDefinedArray(program.getResolvedProjectReferences()),
+    );
+
+    const sourceFile = host.getSourceFile(
+      fileURLToPath(import.meta.url),
+      ScriptTarget.ES2020,
+    );
+
+    expect(sourceFile).toBeDefined();
+    expect(sourceFile?.fileName).toBe(fileURLToPath(import.meta.url));
+  });
+});

--- a/packages/cli/src/project-references.ts
+++ b/packages/cli/src/project-references.ts
@@ -1,0 +1,184 @@
+import assert from 'assert';
+import type {
+  CompilerHost,
+  CompilerOptions,
+  ResolvedProjectReference,
+} from 'typescript';
+import typescript from 'typescript';
+
+import { getDefinedArray } from './utils.js';
+
+const { createCompilerHost, getOutputFileNames } = typescript;
+
+/**
+ * A dependency graph where each value has a list of dependencies.
+ *
+ * @template Value - The type of the values in the graph.
+ */
+export type DependencyGraph<Value> = Map<Value, Value[]>;
+
+/**
+ * Create a dependency graph from the resolved project references.
+ *
+ * @param resolvedProjectReferences - The resolved project references of the
+ * package that is being built.
+ * @returns The dependency graph.
+ */
+export function createGraph(
+  resolvedProjectReferences: readonly ResolvedProjectReference[],
+): DependencyGraph<ResolvedProjectReference> {
+  const graph: DependencyGraph<ResolvedProjectReference> = new Map();
+
+  for (const projectReference of resolvedProjectReferences) {
+    graph.set(projectReference, getDefinedArray(projectReference.references));
+  }
+
+  return graph;
+}
+
+/**
+ * The result of a topological sort.
+ *
+ * @template Value - The type of the values in the graph.
+ */
+export type TopologicalSortResult<Value> = {
+  /**
+   * The sorted nodes.
+   */
+  stack: Value[];
+
+  /**
+   * Whether there was a cycle in the graph.
+   */
+  cycle: boolean;
+};
+
+/**
+ * Topologically sort a dependency graph, i.e., sort the nodes in the graph such
+ * that all dependencies of a node come before the node itself.
+ *
+ * @param graph - The dependency graph to sort.
+ * @returns The topologically sorted nodes and whether there was a cycle.
+ */
+export function topologicalSort<Value>(
+  graph: DependencyGraph<Value>,
+): TopologicalSortResult<Value> {
+  const stack: Value[] = [];
+  const visited = new Set<Value>();
+  const recursionStack = new Set<Value>();
+  let cycle = false;
+
+  /**
+   * Visit a node in the graph.
+   *
+   * @param node - The node to visit.
+   */
+  function visit(node: Value) {
+    if (recursionStack.has(node)) {
+      cycle = true;
+      return;
+    }
+
+    if (visited.has(node)) {
+      return;
+    }
+
+    recursionStack.add(node);
+    visited.add(node);
+
+    const neighbours = graph.get(node);
+    assert(neighbours !== undefined);
+
+    neighbours.forEach(visit);
+    recursionStack.delete(node);
+    stack.push(node);
+  }
+
+  for (const node of graph.keys()) {
+    visit(node);
+  }
+
+  return {
+    stack,
+    cycle,
+  };
+}
+
+/**
+ * Get the resolved project references from a TypeScript program.
+ *
+ * @param resolvedProjectReferences - The resolved project references of the
+ * package that is being built.
+ * @returns The resolved project references.
+ */
+export function getResolvedProjectReferences(
+  resolvedProjectReferences: ResolvedProjectReference[],
+) {
+  const graph = createGraph(resolvedProjectReferences);
+  const { stack, cycle } = topologicalSort(graph);
+
+  if (cycle) {
+    throw new Error(
+      'Unable to build project references due to a dependency cycle.',
+    );
+  }
+
+  return stack;
+}
+
+/**
+ * Get a list of the output file paths in the referenced projects.
+ *
+ * @param resolvedProjectReferences - The resolved project references of the
+ * package that is being built.
+ * @returns A list of output paths.
+ */
+export function getReferencedProjectPaths(
+  resolvedProjectReferences: readonly ResolvedProjectReference[],
+): string[] {
+  return resolvedProjectReferences.flatMap(({ commandLine }) => {
+    return commandLine.fileNames.flatMap((fileName) =>
+      getOutputFileNames(commandLine, fileName, false),
+    );
+  });
+}
+
+/**
+ * Create a compiler host that can be used to build projects using
+ * project references.
+ *
+ * This is almost the same as the default compiler host, but it modifies the
+ * `getSourceFile` method to look at `.d.cts` files instead of `.d.ts` files for
+ * declaration files.
+ *
+ * @param compilerOptions - The compiler options to use.
+ * @param resolvedProjectReferences - The resolved project references of the
+ * package that is being built.
+ * @returns The compiler host.
+ */
+export function createProjectReferencesCompilerHost(
+  compilerOptions: CompilerOptions,
+  resolvedProjectReferences: readonly ResolvedProjectReference[],
+): CompilerHost {
+  const host = createCompilerHost(compilerOptions);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  const referencedProjectPaths = getReferencedProjectPaths(
+    resolvedProjectReferences,
+  );
+
+  const getSourceFile: CompilerHost['getSourceFile'] = (fileName, ...args) => {
+    if (!referencedProjectPaths.includes(fileName)) {
+      return originalGetSourceFile(fileName, ...args);
+    }
+
+    // TypeScript checks the referenced distribution files to see if the project
+    // is built. We simply point it to the `.d.cts` files instead of the `.d.ts`
+    // files.
+    return originalGetSourceFile(fileName.replace(/\.ts$/u, '.cts'), ...args);
+  };
+
+  return {
+    ...host,
+    getSourceFile,
+  };
+}

--- a/packages/cli/src/project-references.ts
+++ b/packages/cli/src/project-references.ts
@@ -130,7 +130,7 @@ export function getCyclesError(
     )
     .join('\n');
 
-  return `Unable to build project references due to a dependency cycle:\n${cyclesMessage}`;
+  return `Unable to build project references due to one or more dependency cycles:\n${cyclesMessage}`;
 }
 
 /**

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isObject, getIdentifierName } from './utils.js';
+import { isObject, getIdentifierName, getDefinedArray } from './utils.js';
 
 describe('isObject', () => {
   it('returns `true` if the value is an object', () => {
@@ -52,5 +52,21 @@ describe('getIdentifierName', () => {
     },
   ])('converts "$value" to "$expected"', ({ value, expected }) => {
     expect(getIdentifierName(value)).toBe(expected);
+  });
+});
+
+describe('getDefinedArray', () => {
+  it('returns the array if it is defined', () => {
+    expect(getDefinedArray([1, 2, 3])).toStrictEqual([1, 2, 3]);
+  });
+
+  it('removes undefined values from the array', () => {
+    expect(getDefinedArray([1, undefined, 2, undefined, 3])).toStrictEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it('returns an empty array if the array is undefined', () => {
+    expect(getDefinedArray(undefined)).toStrictEqual([]);
   });
 });

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -25,3 +25,20 @@ export function getIdentifierName(value: string) {
 
   return sanitisedValue;
 }
+
+/**
+ * Get the defined values from an array, removing all `undefined` values. If the
+ * array itself is `undefined`, an empty array is returned.
+ *
+ * @param array - The array to get the defined values from.
+ * @returns The array with all `undefined` values removed.
+ */
+export function getDefinedArray<Type>(
+  array: readonly (Type | undefined)[] | undefined,
+): Type[] {
+  if (!array) {
+    return [];
+  }
+
+  return array.filter((value): value is Type => value !== undefined);
+}

--- a/packages/test-utils/src/fixtures.ts
+++ b/packages/test-utils/src/fixtures.ts
@@ -4,10 +4,11 @@ import { relative, resolve } from 'path';
  * Get the path to a fixture project in the `test/fixtures` directory.
  *
  * @param name - The name of the fixture project.
+ * @param path - Additional path segments to join.
  * @returns The absolute path to the fixture project.
  */
-export function getFixture(name: string): string {
-  return resolve(import.meta.dirname, '..', 'test', 'fixtures', name);
+export function getFixture(name: string, ...path: string[]): string {
+  return resolve(import.meta.dirname, '..', 'test', 'fixtures', name, ...path);
 }
 
 /**

--- a/packages/test-utils/test/fixtures/project-references/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  extends: ['../../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+
+  overrides: [
+    {
+      files: ['*.ts'],
+      rules: {
+        'import-x/extensions': 'off',
+      },
+    },
+  ],
+};

--- a/packages/test-utils/test/fixtures/project-references/package.json
+++ b/packages/test-utils/test/fixtures/project-references/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@ts-bridge/project-references-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-1/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-1/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/test-utils/test/fixtures/project-references/packages/project-1/package.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@project-references-test/project-1",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@project-references-test/project-3": "workspace:^"
+  }
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-1/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-1/src/index.ts
@@ -1,0 +1,3 @@
+import { foo } from '@project-references-test/project-3';
+
+export { foo };

--- a/packages/test-utils/test/fixtures/project-references/packages/project-1/tsconfig.circular.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-1/tsconfig.circular.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../project-3/tsconfig.circular.json"
+    }
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-1/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-1/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../project-3"
+    }
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-2/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-2/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/test-utils/test/fixtures/project-references/packages/project-2/package.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@project-references-test/project-2",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@project-references-test/project-1": "workspace:^"
+  }
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-2/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-2/src/index.ts
@@ -1,0 +1,3 @@
+import { foo } from '@project-references-test/project-1';
+
+export { foo };

--- a/packages/test-utils/test/fixtures/project-references/packages/project-2/tsconfig.circular.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-2/tsconfig.circular.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../project-1/tsconfig.circular.json"
+    }
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-2/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-2/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../project-1"
+    }
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-3/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-3/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/test-utils/test/fixtures/project-references/packages/project-3/package.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-3/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@project-references-test/project-3",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-3/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-3/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = 42;

--- a/packages/test-utils/test/fixtures/project-references/packages/project-3/tsconfig.circular.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-3/tsconfig.circular.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../project-2/tsconfig.circular.json"
+    }
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-3/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-3/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src"]
+}

--- a/packages/test-utils/test/fixtures/project-references/tsconfig.circular.json
+++ b/packages/test-utils/test/fixtures/project-references/tsconfig.circular.json
@@ -1,0 +1,14 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./packages/project-1/tsconfig.circular.json"
+    },
+    {
+      "path": "./packages/project-2/tsconfig.circular.json"
+    },
+    {
+      "path": "./packages/project-3/tsconfig.circular.json"
+    }
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./packages/project-1"
+    },
+    {
+      "path": "./packages/project-2"
+    },
+    {
+      "path": "./packages/project-3"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -938,6 +938,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@project-references-test/project-1@workspace:^, @project-references-test/project-1@workspace:packages/test-utils/test/fixtures/project-references/packages/project-1":
+  version: 0.0.0-use.local
+  resolution: "@project-references-test/project-1@workspace:packages/test-utils/test/fixtures/project-references/packages/project-1"
+  dependencies:
+    "@project-references-test/project-3": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
+"@project-references-test/project-2@workspace:packages/test-utils/test/fixtures/project-references/packages/project-2":
+  version: 0.0.0-use.local
+  resolution: "@project-references-test/project-2@workspace:packages/test-utils/test/fixtures/project-references/packages/project-2"
+  dependencies:
+    "@project-references-test/project-1": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
+"@project-references-test/project-3@workspace:^, @project-references-test/project-3@workspace:packages/test-utils/test/fixtures/project-references/packages/project-3":
+  version: 0.0.0-use.local
+  resolution: "@project-references-test/project-3@workspace:packages/test-utils/test/fixtures/project-references/packages/project-3"
+  languageName: unknown
+  linkType: soft
+
 "@rollup/rollup-android-arm-eabi@npm:4.14.1":
   version: 4.14.1
   resolution: "@rollup/rollup-android-arm-eabi@npm:4.14.1"
@@ -1156,6 +1178,12 @@ __metadata:
 "@ts-bridge/node-16-fixture@workspace:packages/test-utils/test/fixtures/node-16":
   version: 0.0.0-use.local
   resolution: "@ts-bridge/node-16-fixture@workspace:packages/test-utils/test/fixtures/node-16"
+  languageName: unknown
+  linkType: soft
+
+"@ts-bridge/project-references-fixture@workspace:packages/test-utils/test/fixtures/project-references":
+  version: 0.0.0-use.local
+  resolution: "@ts-bridge/project-references-fixture@workspace:packages/test-utils/test/fixtures/project-references"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This adds experimental support for project references. If the specified `tsconfig.json` contains a `references` field, all referenced projects will be sorted based on their dependencies, and built.