### PR TITLE
Inline shims instead of importing from `@ts-bridge/shims`

### DIFF
--- a/packages/cli/src/build.test.ts
+++ b/packages/cli/src/build.test.ts
@@ -11,12 +11,6 @@ import { removeDirectory } from './file-system.js';
 
 const { sys } = typescript;
 
-vi.mock('./shims.js', async (importOriginal) => ({
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  ...(await importOriginal<typeof import('./shims.js')>()),
-  isShimsPackageInstalled: vi.fn(() => true),
-}));
-
 vi.mock('./file-system.js', async (importOriginal) => ({
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   ...(await importOriginal<typeof import('./file-system.js')>()),

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -57,6 +57,11 @@ export async function main(argv: string[]) {
             description:
               'Build project references in the project. Enabled by default if `tsconfig.json` contains project references.',
             default: true,
+          })
+          .option('shims', {
+            type: 'boolean',
+            description: 'Generate shims for environment-specific APIs.',
+            default: true,
           }),
       ({ format, ...options }) => {
         return buildHandler({

--- a/packages/cli/src/project-references.test.ts
+++ b/packages/cli/src/project-references.test.ts
@@ -196,6 +196,7 @@ describe('createProjectReferencesCompilerHost', () => {
       format: ['commonjs', 'module'],
       baseDirectory: FIXTURE_PATH,
       system: sys,
+      shims: false,
     });
   });
 

--- a/packages/cli/src/shims.test.ts
+++ b/packages/cli/src/shims.test.ts
@@ -1,31 +1,126 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getVirtualEnvironment } from '@ts-bridge/test-utils';
+import type { Statement } from 'typescript';
+import { factory } from 'typescript';
+import { describe, expect, it } from 'vitest';
 
-describe('isShimsPackageInstalled', () => {
-  beforeEach(() => {
-    vi.resetModules();
+import {
+  getDirnameGlobalFunction,
+  getDirnameHelperFunction,
+  getFileUrlToPathHelperFunction,
+  getImportMetaUrlFunction,
+  getRequireHelperFunction,
+} from './shims.js';
+
+/**
+ * Compile a statement. This is used to test the output of the shim functions.
+ *
+ * @param node - The statement to compile.
+ * @returns The compiled code.
+ */
+function compile(node: Statement | Statement[]) {
+  const { program, system } = getVirtualEnvironment({
+    files: {
+      '/index.ts': '// no-op',
+    },
   });
 
-  it('returns true if the package is installed', async () => {
-    vi.doMock('module', () => ({
-      createRequire: vi.fn(() => ({
-        resolve: vi.fn(),
-      })),
-    }));
-
-    const { isShimsPackageInstalled } = await import('./shims.js');
-    expect(isShimsPackageInstalled(import.meta.url)).toBe(true);
+  const statements = Array.isArray(node) ? node : [node];
+  program.emit(undefined, undefined, undefined, false, {
+    before: [
+      () => {
+        return (sourceFile) => {
+          // TypeScript doesn't provide a nice way to add a new source file, so
+          // instead we update the dummy source file with the new node.
+          return factory.updateSourceFile(sourceFile, statements);
+        };
+      },
+    ],
   });
 
-  it('returns false if the package is not installed', async () => {
-    vi.doMock('module', () => ({
-      createRequire: vi.fn(() => ({
-        resolve: vi.fn(() => {
-          throw new Error();
-        }),
-      })),
-    }));
+  return system.readFile('/index.js');
+}
 
-    const { isShimsPackageInstalled } = await import('./shims.js');
-    expect(isShimsPackageInstalled(import.meta.url)).toBe(false);
+describe('getFileUrlToPathHelperFunction', () => {
+  it('returns the `fileUrlToPath` function', () => {
+    const ast = getFileUrlToPathHelperFunction('fileUrlToPath');
+
+    expect(compile(ast)).toMatchInlineSnapshot(`
+      ""use strict";
+      function fileUrlToPath(fileUrl) {
+          const url = new URL(fileUrl);
+          return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
+      }
+      "
+    `);
+  });
+});
+
+describe('getDirnameHelperFunction', () => {
+  it('returns the `dirname` function', () => {
+    const ast = getDirnameHelperFunction('dirname');
+
+    expect(compile(ast)).toMatchInlineSnapshot(`
+      ""use strict";
+      function dirname(path) {
+          const sanitisedPath = path.toString().replace(/\\\\/gu, "/").replace(/\\/$/u, "");
+          const index = sanitisedPath.lastIndexOf("/");
+          if (index === -1) {
+              return path;
+          }
+          if (index === 0) {
+              return "/";
+          }
+          return sanitisedPath.slice(0, index);
+      }
+      "
+    `);
+  });
+});
+
+describe('getDirnameGlobalFunction', () => {
+  it('returns the `dirname` global function', () => {
+    const ast = getDirnameGlobalFunction(
+      'dirname',
+      'fileUrlToPath',
+      'getDirname',
+    );
+
+    expect(compile(ast)).toMatchInlineSnapshot(`
+      ""use strict";
+      function dirname(url) {
+          return getDirname(fileUrlToPath(url));
+      }
+      "
+    `);
+  });
+});
+
+describe('getImportMetaUrlFunction', () => {
+  it('returns the `importMetaUrl` function', () => {
+    const ast = getImportMetaUrlFunction('importMetaUrl');
+
+    expect(compile(ast)).toMatchInlineSnapshot(`
+      ""use strict";
+      function importMetaUrl(fileName) {
+          return typeof document === "undefined" ? new URL(\`file:\${fileName}\`).href : document.currentScript?.src ?? new URL("main.js", document.baseURI).href;
+      }
+      "
+    `);
+  });
+});
+
+describe('getRequireHelperFunction', () => {
+  it('returns the `require` helper function', () => {
+    const ast = getRequireHelperFunction('require');
+
+    expect(compile(ast)).toMatchInlineSnapshot(`
+      ""use strict";
+      import { createRequire as require } from "module";
+      function require(identifier, url) {
+          const fn = require(url);
+          return fn(identifier);
+      }
+      "
+    `);
   });
 });

--- a/packages/cli/src/shims.ts
+++ b/packages/cli/src/shims.ts
@@ -1,29 +1,7 @@
-import { createRequire } from 'module';
 import type { Statement } from 'typescript';
 import typescript from 'typescript';
 
 const { factory, SyntaxKind, NodeFlags } = typescript;
-
-export const CJS_SHIMS_PACKAGE = '@ts-bridge/shims';
-export const ESM_SHIMS_PACKAGE = '@ts-bridge/shims/esm';
-export const ESM_REQUIRE_SHIMS_PACKAGE = '@ts-bridge/shims/esm/require';
-
-/**
- * Check if the `@ts-bridge/shims` package is installed.
- *
- * @param basePath - The path to start resolving from. This should be a `file:`
- * path and include the filename, e.g., `import.meta.url`.
- * @returns `true` if the package is installed, `false` otherwise.
- */
-export function isShimsPackageInstalled(basePath: string) {
-  const require = createRequire(basePath);
-  try {
-    require.resolve(CJS_SHIMS_PACKAGE);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Get the AST for the `fileURLToPath` function, i.e.:

--- a/packages/cli/src/shims.ts
+++ b/packages/cli/src/shims.ts
@@ -1,4 +1,8 @@
 import { createRequire } from 'module';
+import type { Statement } from 'typescript';
+import typescript from 'typescript';
+
+const { factory, SyntaxKind, NodeFlags } = typescript;
 
 export const CJS_SHIMS_PACKAGE = '@ts-bridge/shims';
 export const ESM_SHIMS_PACKAGE = '@ts-bridge/shims/esm';
@@ -19,4 +23,499 @@ export function isShimsPackageInstalled(basePath: string) {
   } catch {
     return false;
   }
+}
+
+/**
+ * Get the AST for the `fileURLToPath` function, i.e.:
+ *
+ * ```ts
+ * function fileURLToPath(fileUrl: string) {
+ *   const url = new URL(fileUrl);
+ *   return url.pathname.replace(/^\/([a-zA-Z]:)/u, '$1');
+ * }
+ * ```
+ *
+ * This function is a simplified version of the `fileURLToPath` function in
+ * Node.js and does not handle edge cases like file URLs that contain invalid
+ * characters. It is assumed that the input is always a valid file URL.
+ *
+ * This is used to avoid the need for polyfills in browser environment.
+ *
+ * @param functionName - The name of the function to create.
+ * @returns The AST for the `fileURLToPath` function.
+ */
+export function getFileUrlToPathHelperFunction(functionName: string) {
+  return factory.createFunctionDeclaration(
+    undefined,
+    undefined,
+    factory.createIdentifier(functionName),
+    undefined,
+    [
+      factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        factory.createIdentifier('fileUrl'),
+        undefined,
+        factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+        undefined,
+      ),
+    ],
+    undefined,
+    factory.createBlock(
+      [
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier('url'),
+                undefined,
+                undefined,
+                factory.createNewExpression(
+                  factory.createIdentifier('URL'),
+                  undefined,
+                  [factory.createIdentifier('fileUrl')],
+                ),
+              ),
+            ],
+            NodeFlags.Const,
+          ),
+        ),
+        factory.createReturnStatement(
+          factory.createCallExpression(
+            factory.createPropertyAccessExpression(
+              factory.createPropertyAccessExpression(
+                factory.createIdentifier('url'),
+                factory.createIdentifier('pathname'),
+              ),
+              factory.createIdentifier('replace'),
+            ),
+            undefined,
+            [
+              factory.createRegularExpressionLiteral('/^\\/([a-zA-Z]:)/u'),
+              factory.createStringLiteral('$1'),
+            ],
+          ),
+        ),
+      ],
+      true,
+    ),
+  );
+}
+
+/**
+ * Get the AST for the `dirname` function, i.e.:
+ *
+ * ```ts
+ * function dirname(path: string) {
+ *   const sanitisedPath = path
+ *     .toString()
+ *     .replace(/\\/gu, '/')
+ *     .replace(/\/$/u, '');
+ *
+ *   const index = sanitisedPath.lastIndexOf('/');
+ *   if (index === -1) {
+ *     return path;
+ *   }
+ *
+ *   if (index === 0) {
+ *     return '/';
+ *   }
+ *
+ *   return sanitisedPath.slice(0, index);
+ * }
+ * ```
+ *
+ * This function is a simplified version of the `dirname` function in Node.js.
+ * It does not handle edge cases like paths that end with multiple slashes or
+ * paths that contain invalid characters. It is assumed that the input is always
+ * a valid path.
+ *
+ * This is used to avoid the need for polyfills in browser environment.
+ *
+ * @param functionName - The name of the function to create.
+ * @returns The AST for the `dirname` function.
+ */
+export function getDirnameHelperFunction(functionName: string) {
+  return factory.createFunctionDeclaration(
+    undefined,
+    undefined,
+    factory.createIdentifier(functionName),
+    undefined,
+    [
+      factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        factory.createIdentifier('path'),
+        undefined,
+        factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+        undefined,
+      ),
+    ],
+    undefined,
+    factory.createBlock(
+      [
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier('sanitisedPath'),
+                undefined,
+                undefined,
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createCallExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createCallExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier('path'),
+                            factory.createIdentifier('toString'),
+                          ),
+                          undefined,
+                          [],
+                        ),
+                        factory.createIdentifier('replace'),
+                      ),
+                      undefined,
+                      [
+                        factory.createRegularExpressionLiteral('/\\\\/gu'),
+                        factory.createStringLiteral('/'),
+                      ],
+                    ),
+                    factory.createIdentifier('replace'),
+                  ),
+                  undefined,
+                  [
+                    factory.createRegularExpressionLiteral('/\\/$/u'),
+                    factory.createStringLiteral(''),
+                  ],
+                ),
+              ),
+            ],
+            NodeFlags.Const,
+          ),
+        ),
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier('index'),
+                undefined,
+                undefined,
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier('sanitisedPath'),
+                    factory.createIdentifier('lastIndexOf'),
+                  ),
+                  undefined,
+                  [factory.createStringLiteral('/')],
+                ),
+              ),
+            ],
+            NodeFlags.Const,
+          ),
+        ),
+        factory.createIfStatement(
+          factory.createBinaryExpression(
+            factory.createIdentifier('index'),
+            factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+            factory.createPrefixUnaryExpression(
+              SyntaxKind.MinusToken,
+              factory.createNumericLiteral('1'),
+            ),
+          ),
+          factory.createBlock(
+            [factory.createReturnStatement(factory.createIdentifier('path'))],
+            true,
+          ),
+          undefined,
+        ),
+        factory.createIfStatement(
+          factory.createBinaryExpression(
+            factory.createIdentifier('index'),
+            factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+            factory.createNumericLiteral('0'),
+          ),
+          factory.createBlock(
+            [factory.createReturnStatement(factory.createStringLiteral('/'))],
+            true,
+          ),
+          undefined,
+        ),
+        factory.createReturnStatement(
+          factory.createCallExpression(
+            factory.createPropertyAccessExpression(
+              factory.createIdentifier('sanitisedPath'),
+              factory.createIdentifier('slice'),
+            ),
+            undefined,
+            [
+              factory.createNumericLiteral('0'),
+              factory.createIdentifier('index'),
+            ],
+          ),
+        ),
+      ],
+      true,
+    ),
+  );
+}
+
+/**
+ * Get the AST for the `__dirname` global function, i.e.:
+ *
+ * ```ts
+ * function __dirname(url: string): string {
+ *   return dirname(fileUrlToPath(url));
+ * }
+ * ```
+ *
+ * This function returns the directory name of the current module, i.e.,
+ * `__dirname`, but for ESM.
+ *
+ * @param functionName - The name of the function to create.
+ * @param fileUrlToPathFunctionName - The name of the function that converts a
+ * file URL to a path.
+ * @param dirnameFunctionName - The name of the function that gets the directory
+ * name of a path.
+ * @returns The AST for the `__dirname` global function.
+ */
+export function getDirnameGlobalFunction(
+  functionName: string,
+  fileUrlToPathFunctionName: string,
+  dirnameFunctionName: string,
+) {
+  return factory.createFunctionDeclaration(
+    undefined,
+    undefined,
+    factory.createIdentifier(functionName),
+    undefined,
+    [
+      factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        factory.createIdentifier('url'),
+        undefined,
+        factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+        undefined,
+      ),
+    ],
+    factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+    factory.createBlock(
+      [
+        factory.createReturnStatement(
+          factory.createCallExpression(
+            factory.createIdentifier(dirnameFunctionName),
+            undefined,
+            [
+              factory.createCallExpression(
+                factory.createIdentifier(fileUrlToPathFunctionName),
+                undefined,
+                [factory.createIdentifier('url')],
+              ),
+            ],
+          ),
+        ),
+      ],
+      true,
+    ),
+  );
+}
+
+/**
+ * Get the AST for the `getImportMetaUrl` function, i.e.:
+ *
+ * ```ts
+ * function getImportMetaUrl(fileName: string): string {
+ *   return typeof document === 'undefined'
+ *     ? new URL(`file:${fileName}`).href
+ *     : document.currentScript?.src ?? new URL('main.js', document.baseURI).href;
+ * }
+ * ```
+ *
+ * If the current environment is a browser, it will return the URL of the
+ * current script (if it's available). Otherwise, it will return the URL of the
+ * current file.
+ *
+ * @param functionName - The name of the function to create.
+ * @returns The AST for the `getImportMetaUrl` function.
+ */
+export function getImportMetaUrlFunction(functionName: string) {
+  return factory.createFunctionDeclaration(
+    undefined,
+    undefined,
+    factory.createIdentifier(functionName),
+    undefined,
+    [
+      factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        factory.createIdentifier('fileName'),
+        undefined,
+        factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+        undefined,
+      ),
+    ],
+    factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+    factory.createBlock(
+      [
+        factory.createReturnStatement(
+          factory.createConditionalExpression(
+            factory.createBinaryExpression(
+              factory.createTypeOfExpression(
+                factory.createIdentifier('document'),
+              ),
+              factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+              factory.createStringLiteral('undefined'),
+            ),
+            factory.createToken(SyntaxKind.QuestionToken),
+            factory.createPropertyAccessExpression(
+              factory.createNewExpression(
+                factory.createIdentifier('URL'),
+                undefined,
+                [
+                  factory.createTemplateExpression(
+                    factory.createTemplateHead('file:', 'file:'),
+                    [
+                      factory.createTemplateSpan(
+                        factory.createIdentifier('fileName'),
+                        factory.createTemplateTail('', ''),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              factory.createIdentifier('href'),
+            ),
+            factory.createToken(SyntaxKind.ColonToken),
+            factory.createBinaryExpression(
+              factory.createPropertyAccessChain(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier('document'),
+                  factory.createIdentifier('currentScript'),
+                ),
+                factory.createToken(SyntaxKind.QuestionDotToken),
+                factory.createIdentifier('src'),
+              ),
+              factory.createToken(SyntaxKind.QuestionQuestionToken),
+              factory.createPropertyAccessExpression(
+                factory.createNewExpression(
+                  factory.createIdentifier('URL'),
+                  undefined,
+                  [
+                    factory.createStringLiteral('main.js'),
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('document'),
+                      factory.createIdentifier('baseURI'),
+                    ),
+                  ],
+                ),
+                factory.createIdentifier('href'),
+              ),
+            ),
+          ),
+        ),
+      ],
+      true,
+    ),
+  );
+}
+
+/**
+ * Get the AST for the `require` function, i.e.:
+ *
+ * ```ts
+ * import { createRequire } from 'module';
+ *
+ * function require(identifier: string, url: string): any {
+ *   const fn = createRequire(url);
+ *   return fn(identifier);
+ * }
+ * ```
+ *
+ * This is a shim for Node.js's `require` function, and is intended to be used
+ * in ESM modules. Note that this function cannot be used to import ESM modules,
+ * only CJS modules.
+ *
+ * @param functionName - The name of the function to create.
+ * @returns The AST for the `require` function.
+ */
+export function getRequireHelperFunction(
+  functionName: string,
+): [Statement, Statement] {
+  return [
+    factory.createImportDeclaration(
+      undefined,
+      factory.createImportClause(
+        false,
+        undefined,
+        factory.createNamedImports([
+          factory.createImportSpecifier(
+            false,
+            factory.createIdentifier('createRequire'),
+            factory.createIdentifier(functionName),
+          ),
+        ]),
+      ),
+      factory.createStringLiteral('module'),
+      undefined,
+    ),
+    factory.createFunctionDeclaration(
+      undefined,
+      undefined,
+      factory.createIdentifier('require'),
+      undefined,
+      [
+        factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          factory.createIdentifier('identifier'),
+          undefined,
+          factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+          undefined,
+        ),
+        factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          factory.createIdentifier('url'),
+          undefined,
+          factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+          undefined,
+        ),
+      ],
+      factory.createKeywordTypeNode(SyntaxKind.AnyKeyword),
+      factory.createBlock(
+        [
+          factory.createVariableStatement(
+            undefined,
+            factory.createVariableDeclarationList(
+              [
+                factory.createVariableDeclaration(
+                  factory.createIdentifier('fn'),
+                  undefined,
+                  undefined,
+                  factory.createCallExpression(
+                    factory.createIdentifier(functionName),
+                    undefined,
+                    [factory.createIdentifier('url')],
+                  ),
+                ),
+              ],
+              NodeFlags.Const,
+            ),
+          ),
+          factory.createReturnStatement(
+            factory.createCallExpression(
+              factory.createIdentifier('fn'),
+              undefined,
+              [factory.createIdentifier('identifier')],
+            ),
+          ),
+        ],
+        true,
+      ),
+    ),
+  ];
 }

--- a/packages/cli/src/transformers.test.ts
+++ b/packages/cli/src/transformers.test.ts
@@ -534,25 +534,11 @@ describe('getGlobalsTransformer', () => {
 
     it('adds a shim when using `__filename`', async () => {
       expect(files['filename.js']).toMatchInlineSnapshot(`
-        "function $getDirname(path) {
-            const sanitisedPath = path.toString().replace(/\\\\/gu, "/").replace(/\\/$/u, "");
-            const index = sanitisedPath.lastIndexOf("/");
-            if (index === -1) {
-                return path;
-            }
-            if (index === 0) {
-                return "/";
-            }
-            return sanitisedPath.slice(0, index);
-        }
-        function $fileUrlToPath(fileUrl) {
+        "function $__filename(fileUrl) {
             const url = new URL(fileUrl);
             return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
         }
-        function $__dirname(url) {
-            return $getDirname($fileUrlToPath(url));
-        }
-        console.log($fileUrlToPath(import.meta.url));
+        console.log($__filename(import.meta.url));
         export {};
         "
       `);
@@ -560,7 +546,11 @@ describe('getGlobalsTransformer', () => {
 
     it('adds a shim when using `__dirname`', async () => {
       expect(files['dirname.js']).toMatchInlineSnapshot(`
-        "function $getDirname(path) {
+        "function $__filename(fileUrl) {
+            const url = new URL(fileUrl);
+            return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
+        }
+        function $getDirname(path) {
             const sanitisedPath = path.toString().replace(/\\\\/gu, "/").replace(/\\/$/u, "");
             const index = sanitisedPath.lastIndexOf("/");
             if (index === -1) {
@@ -571,12 +561,8 @@ describe('getGlobalsTransformer', () => {
             }
             return sanitisedPath.slice(0, index);
         }
-        function $fileUrlToPath(fileUrl) {
-            const url = new URL(fileUrl);
-            return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
-        }
         function $__dirname(url) {
-            return $getDirname($fileUrlToPath(url));
+            return $getDirname($__filename(url));
         }
         console.log($__dirname(import.meta.url));
         export {};
@@ -586,7 +572,11 @@ describe('getGlobalsTransformer', () => {
 
     it('adds a shim when using both `__filename` and `__dirname`', async () => {
       expect(files['multiple.js']).toMatchInlineSnapshot(`
-        "function $getDirname(path) {
+        "function $__filename(fileUrl) {
+            const url = new URL(fileUrl);
+            return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
+        }
+        function $getDirname(path) {
             const sanitisedPath = path.toString().replace(/\\\\/gu, "/").replace(/\\/$/u, "");
             const index = sanitisedPath.lastIndexOf("/");
             if (index === -1) {
@@ -597,14 +587,10 @@ describe('getGlobalsTransformer', () => {
             }
             return sanitisedPath.slice(0, index);
         }
-        function $fileUrlToPath(fileUrl) {
-            const url = new URL(fileUrl);
-            return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
-        }
         function $__dirname(url) {
-            return $getDirname($fileUrlToPath(url));
+            return $getDirname($__filename(url));
         }
-        console.log($__dirname(import.meta.url), $fileUrlToPath(import.meta.url));
+        console.log($__dirname(import.meta.url), $__filename(import.meta.url));
         export {};
         "
       `);
@@ -612,26 +598,12 @@ describe('getGlobalsTransformer', () => {
 
     it('renames the shim when the name is already used in the scope', async () => {
       expect(files['rename.js']).toMatchInlineSnapshot(`
-        "function $getDirname(path) {
-            const sanitisedPath = path.toString().replace(/\\\\/gu, "/").replace(/\\/$/u, "");
-            const index = sanitisedPath.lastIndexOf("/");
-            if (index === -1) {
-                return path;
-            }
-            if (index === 0) {
-                return "/";
-            }
-            return sanitisedPath.slice(0, index);
-        }
-        function $fileUrlToPath(fileUrl) {
+        "function $__filename(fileUrl) {
             const url = new URL(fileUrl);
             return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
         }
-        function $__dirname(url) {
-            return $getDirname($fileUrlToPath(url));
-        }
         const $dirname = 'foo';
-        console.log($dirname, $fileUrlToPath(import.meta.url));
+        console.log($dirname, $__filename(import.meta.url));
         export {};
         "
       `);

--- a/packages/cli/src/transformers.test.ts
+++ b/packages/cli/src/transformers.test.ts
@@ -534,33 +534,105 @@ describe('getGlobalsTransformer', () => {
 
     it('adds a shim when using `__filename`', async () => {
       expect(files['filename.js']).toMatchInlineSnapshot(`
-        "import * as $shims from "@ts-bridge/shims/esm";
-        console.log($shims.__filename(import.meta.url));
+        "function $getDirname(path) {
+            const sanitisedPath = path.toString().replace(/\\\\/gu, "/").replace(/\\/$/u, "");
+            const index = sanitisedPath.lastIndexOf("/");
+            if (index === -1) {
+                return path;
+            }
+            if (index === 0) {
+                return "/";
+            }
+            return sanitisedPath.slice(0, index);
+        }
+        function $fileUrlToPath(fileUrl) {
+            const url = new URL(fileUrl);
+            return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
+        }
+        function $__dirname(url) {
+            return $getDirname($fileUrlToPath(url));
+        }
+        console.log($fileUrlToPath(import.meta.url));
+        export {};
         "
       `);
     });
 
     it('adds a shim when using `__dirname`', async () => {
       expect(files['dirname.js']).toMatchInlineSnapshot(`
-        "import * as $shims from "@ts-bridge/shims/esm";
-        console.log($shims.__dirname(import.meta.url));
+        "function $getDirname(path) {
+            const sanitisedPath = path.toString().replace(/\\\\/gu, "/").replace(/\\/$/u, "");
+            const index = sanitisedPath.lastIndexOf("/");
+            if (index === -1) {
+                return path;
+            }
+            if (index === 0) {
+                return "/";
+            }
+            return sanitisedPath.slice(0, index);
+        }
+        function $fileUrlToPath(fileUrl) {
+            const url = new URL(fileUrl);
+            return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
+        }
+        function $__dirname(url) {
+            return $getDirname($fileUrlToPath(url));
+        }
+        console.log($__dirname(import.meta.url));
+        export {};
         "
       `);
     });
 
     it('adds a shim when using both `__filename` and `__dirname`', async () => {
       expect(files['multiple.js']).toMatchInlineSnapshot(`
-        "import * as $shims from "@ts-bridge/shims/esm";
-        console.log($shims.__dirname(import.meta.url), $shims.__filename(import.meta.url));
+        "function $getDirname(path) {
+            const sanitisedPath = path.toString().replace(/\\\\/gu, "/").replace(/\\/$/u, "");
+            const index = sanitisedPath.lastIndexOf("/");
+            if (index === -1) {
+                return path;
+            }
+            if (index === 0) {
+                return "/";
+            }
+            return sanitisedPath.slice(0, index);
+        }
+        function $fileUrlToPath(fileUrl) {
+            const url = new URL(fileUrl);
+            return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
+        }
+        function $__dirname(url) {
+            return $getDirname($fileUrlToPath(url));
+        }
+        console.log($__dirname(import.meta.url), $fileUrlToPath(import.meta.url));
+        export {};
         "
       `);
     });
 
     it('renames the shim when the name is already used in the scope', async () => {
       expect(files['rename.js']).toMatchInlineSnapshot(`
-        "import * as $_shims from "@ts-bridge/shims/esm";
-        const $shims = 'foo';
-        console.log($shims, $_shims.__filename(import.meta.url));
+        "function $getDirname(path) {
+            const sanitisedPath = path.toString().replace(/\\\\/gu, "/").replace(/\\/$/u, "");
+            const index = sanitisedPath.lastIndexOf("/");
+            if (index === -1) {
+                return path;
+            }
+            if (index === 0) {
+                return "/";
+            }
+            return sanitisedPath.slice(0, index);
+        }
+        function $fileUrlToPath(fileUrl) {
+            const url = new URL(fileUrl);
+            return url.pathname.replace(/^\\/([a-zA-Z]:)/u, "$1");
+        }
+        function $__dirname(url) {
+            return $getDirname($fileUrlToPath(url));
+        }
+        const $dirname = 'foo';
+        console.log($dirname, $fileUrlToPath(import.meta.url));
+        export {};
         "
       `);
     });
@@ -593,8 +665,12 @@ describe('getRequireTransformer', () => {
 
     it('adds a shim when using `require`', async () => {
       expect(files['require.js']).toMatchInlineSnapshot(`
-        "import * as $nodeShims from "@ts-bridge/shims/esm/require";
-        const { builtinModules } = $nodeShims.require('module', import.meta.url);
+        "import { createRequire as $createRequire } from "module";
+        function require(identifier, url) {
+            const fn = $createRequire(url);
+            return fn(identifier);
+        }
+        const { builtinModules } = require('module', import.meta.url);
         console.log(builtinModules);
         "
       `);
@@ -630,33 +706,12 @@ describe('getImportMetaTransformer', () => {
     it('adds a shim when using `import.meta.url`', async () => {
       expect(files['import-meta.js']).toMatchInlineSnapshot(`
         ""use strict";
-        var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-            if (k2 === undefined) k2 = k;
-            var desc = Object.getOwnPropertyDescriptor(m, k);
-            if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-              desc = { enumerable: true, get: function() { return m[k]; } };
-            }
-            Object.defineProperty(o, k2, desc);
-        }) : (function(o, m, k, k2) {
-            if (k2 === undefined) k2 = k;
-            o[k2] = m[k];
-        }));
-        var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-            Object.defineProperty(o, "default", { enumerable: true, value: v });
-        }) : function(o, v) {
-            o["default"] = v;
-        });
-        var __importStar = (this && this.__importStar) || function (mod) {
-            if (mod && mod.__esModule) return mod;
-            var result = {};
-            if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-            __setModuleDefault(result, mod);
-            return result;
-        };
         Object.defineProperty(exports, "__esModule", { value: true });
-        const $shims = __importStar(require("@ts-bridge/shims"));
+        function $getImportMetaUrl(fileName) {
+            return typeof document === "undefined" ? new URL(\`file:\${fileName}\`).href : document.currentScript?.src ?? new URL("main.js", document.baseURI).href;
+        }
         // @ts-expect-error - \`import.meta.url\` isn't allowed here.
-        console.log($shims.getImportMetaUrl(__filename));
+        console.log($getImportMetaUrl(__filename));
         "
       `);
     });

--- a/packages/cli/src/transformers.ts
+++ b/packages/cli/src/transformers.ts
@@ -247,10 +247,12 @@ export function getExportExtensionTransformer(
  * ```
  *
  * will be transformed to:
- * ```
- * import * as shims from '@ts-bridge/shims/esm';
+ * ```ts
+ * function $__filename(url) {
+ *   // ...;
+ * }
  *
- * const foo = shims.__filename(import.meta.url);
+ * const foo = $__filename(import.meta.url);
  * ```
  *
  * This should only be used for the ES module target.
@@ -359,10 +361,12 @@ export function getGlobalsTransformer({ typeChecker }: TransformerOptions) {
  * ```
  *
  * will be transformed to:
- * ```
- * import * as nodeShims from '@ts-bridge/shims/esm/require';
+ * ```ts
+ * function require(path, url) {
+ *   // ...;
+ * }
  *
- * const foo = nodeShims.require('bar', import.meta.url);
+ * const foo = require('bar', import.meta.url);
  * ```
  *
  * This should only be used for the ES module target.
@@ -426,9 +430,11 @@ export const getRequireTransformer = ({ typeChecker }: TransformerOptions) => {
  *
  * will be transformed to:
  * ```ts
- * import * as shims from '@ts-bridge/shims';
+ * function getImportMetaUrl(filename) {
+ *   // ...;
+ * }
  *
- * const foo = shims.getImportMetaUrl(__filename);
+ * const foo = getImportMetaUrl(__filename);
  * ```
  *
  * This should only be used for the CommonJS target.

--- a/packages/test-utils/test/fixtures/globals/src/rename.ts
+++ b/packages/test-utils/test/fixtures/globals/src/rename.ts
@@ -1,2 +1,2 @@
-const $shims = 'foo';
-console.log($shims, __filename);
+const $dirname = 'foo';
+console.log($dirname, __filename);


### PR DESCRIPTION
This removes the need for installing the `@ts-bridge/shims` package by inlining shims instead, after @FrederikBolding and @rekmarks suggested that this is the preferable solution.

Shims will be inserted in each file that needs them. For example, if a file uses `__dirname`, which will be compiled to ESM, the `dirname` helper function (and some dependency functions) are inserted into that file. Note that shims are now opt-out (by specifying `--no-shims` or `--shims false`) rather than opt-in (by installing the shims package previously). I suppose this could be considered a breaking change.