### PR TITLE
Update documentation about shims

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -29,25 +29,3 @@ $ yarn add -D @ts-bridge/cli typescript
 ```
 
 +++
-
-## Installing the shims package (optional)
-
-If you want to use the shims provided by TS Bridge, you can install the
-`@ts-bridge/shims` package as well. Make sure to install it as a **regular
-dependency**:
-
-+++ NPM
-
-```shell
-$ npm install --save @ts-bridge/shims
-```
-
-+++ Yarn
-
-```shell
-$ yarn add @ts-bridge/shims
-```
-
-+++
-
-The shims will automatically be enabled when the package is installed.

--- a/docs/reference/command-line-options.md
+++ b/docs/reference/command-line-options.md
@@ -86,6 +86,22 @@ they are detected in the `tsconfig.json` file.
 $ ts-bridge build --references
 ```
 
+### `--shims`
+
+- Type: `boolean`
+- Default: `true`
+
+Enable or disable shims for CommonJS and ESM environments. Shims are enabled by
+default. To disable them, specify `--shims false`, or `--no-shims`.
+
+```shell
+$ ts-bridge build --shims false
+```
+
+```shell
+$ ts-bridge build --no-shims
+```
+
 ### `--verbose`
 
 - Alias: `-v`

--- a/docs/reference/shims.md
+++ b/docs/reference/shims.md
@@ -5,21 +5,18 @@ icon: code-square
 
 # Shims
 
-If the `@ts-bridge/shims` package is installed, TS Bridge will automatically
+When shims are enabled (which is the default), TS Bridge will automatically
 use it to provide shims for certain APIs that are not available in the target
 environment. This is useful for using APIs specific to CommonJS environments
 such as `__dirname` and `__filename`, or `import.meta.url` in ESM environments.
-The shims are provided by the `@ts-bridge/shims` package, which is an optional
-peer dependency of TS Bridge.
 
 This means that you can use these APIs in your TypeScript code, and TS Bridge
 will automatically provide the necessary shims when compiling the code. This
 makes it easier to write code that works in both CommonJS and ESM environments.
 
 > [!NOTE]
-> You should not import from the `@ts-bridge/shims` package directly in your
-> code. TS Bridge will automatically provide the necessary shims when compiling
-> your code.
+> Shims are enabled by default, but you can disable them by specifying
+> `--shims false` or `--no-shims` when running the `ts-bridge` CLI.
 
 The following shims are available:
 
@@ -44,15 +41,18 @@ function getFile(filePath: string) {
 ```
 
 When compiled with TS Bridge, the code will work in both CommonJS and ESM
-environments, as the necessary shims will be provided by the
-`@ts-bridge/shims/esm` package (when targeting ESM).
+environments, as the necessary shims will be provided injected into the output
+code. The ESM version of the code will look something like this:
 
 ```javascript
-import * as $shims from '@ts-bridge/shims/esm';
+function $__dirname(url) {
+  // Some logic to get the directory name from `import.meta.url`.
+}
+
 import { resolve } from 'path';
 
 function getFile(filePath) {
-  return resolve($shims.__dirname(import.meta.url), filePath);
+  return resolve($__dirname(import.meta.url), filePath);
 }
 ```
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,13 +61,7 @@
     "vitest": "^1.5.0"
   },
   "peerDependencies": {
-    "@ts-bridge/shims": "workspace:^",
     "typescript": ">=4.8.0"
-  },
-  "peerDependenciesMeta": {
-    "@ts-bridge/shims": {
-      "optional": true
-    }
   },
   "packageManager": "yarn@4.1.1",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,11 +1139,7 @@ __metadata:
     vitest: "npm:^1.5.0"
     yargs: "npm:^17.7.2"
   peerDependencies:
-    "@ts-bridge/shims": "workspace:^"
     typescript: ">=4.8.0"
-  peerDependenciesMeta:
-    "@ts-bridge/shims":
-      optional: true
   bin:
     ts-bridge: ./dist/index.js
     tsbridge: ./dist/index.js


### PR DESCRIPTION
This updates the docs regarding shims, which removes mentions of the `@ts-bridge/shims` package.