### PR TITLE
Release 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/root",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "private": true,
   "description": "The root package of the monorepo.",
   "homepage": "https://github.com/ts-bridge/ts-bridge#readme",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Add tests for shims and helper functions ([#37](https://github.com/ts-bridge/ts-bridge/pull/37))
+- Update documentation about shims ([#36](https://github.com/ts-bridge/ts-bridge/pull/36))
+- Transform default CommonJS imports ([#19](https://github.com/ts-bridge/ts-bridge/pull/19))
+- Inline shims instead of importing from `@ts-bridge/shims` ([#35](https://github.com/ts-bridge/ts-bridge/pull/35))
+- Detect CommonJS exports using `cjs-module-lexer` ([#34](https://github.com/ts-bridge/ts-bridge/pull/34))
+
 ## [0.3.0]
 
 ### Added

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0]
+
 ### Uncategorized
 
 - Add tests for shims and helper functions ([#37](https://github.com/ts-bridge/ts-bridge/pull/37))
@@ -82,7 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/cli` package.
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.3.0...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.0...HEAD
+[0.4.0]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.3.0...@ts-bridge/cli@0.4.0
 [0.3.0]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.2.0...@ts-bridge/cli@0.3.0
 [0.2.0]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.1.4...@ts-bridge/cli@0.2.0
 [0.1.4]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.1.3...@ts-bridge/cli@0.1.4

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,13 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0]
 
-### Uncategorized
+### Added
 
-- Add tests for shims and helper functions ([#37](https://github.com/ts-bridge/ts-bridge/pull/37))
-- Update documentation about shims ([#36](https://github.com/ts-bridge/ts-bridge/pull/36))
-- Transform default CommonJS imports ([#19](https://github.com/ts-bridge/ts-bridge/pull/19))
-- Inline shims instead of importing from `@ts-bridge/shims` ([#35](https://github.com/ts-bridge/ts-bridge/pull/35))
-- Detect CommonJS exports using `cjs-module-lexer` ([#34](https://github.com/ts-bridge/ts-bridge/pull/34))
+- Add transform default CommonJS imports when targeting ESM ([#19](https://github.com/ts-bridge/ts-bridge/pull/19), [#37](https://github.com/ts-bridge/ts-bridge/pull/37))
+  - Default CommonJS imports are transformed to use a helper function which
+    checks if the module has a `__esModule` property, and returns the default
+    export if it does.
+
+### Changed
+
+- Inline shims instead of importing from `@ts-bridge/shims` ([#35](https://github.com/ts-bridge/ts-bridge/pull/35), [#36](https://github.com/ts-bridge/ts-bridge/pull/36), [#37](https://github.com/ts-bridge/ts-bridge/pull/37))
+  - `@ts-bridge/shims` is now deprecated and no longer used by the tool.
+  - This reduces the number of dependencies and makes the tool more
+    self-contained.
+- Only transform undetected named CommonJS imports ([#34](https://github.com/ts-bridge/ts-bridge/pull/34))
+  - Named CommonJS imports are only transformed if they are not detected as
+    exports.
+    - This uses `cjs-module-lexer` to detect named exports, which is used by
+      Node.js and other tools to detect named exports as well.
 
 ## [0.3.0]
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add transform default CommonJS imports when targeting ESM ([#19](https://github.com/ts-bridge/ts-bridge/pull/19), [#37](https://github.com/ts-bridge/ts-bridge/pull/37))
+- Add transform for default CommonJS imports when targeting ESM ([#19](https://github.com/ts-bridge/ts-bridge/pull/19), [#37](https://github.com/ts-bridge/ts-bridge/pull/37))
   - Default CommonJS imports are transformed to use a helper function which
     checks if the module has a `__esModule` property, and returns the default
     export if it does.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Bridge the gap between ES modules and CommonJS modules with an easy-to-use alternative to `tsc`.",
   "keywords": [
     "build-tool",


### PR DESCRIPTION
This is the release candidate for version `8.0.0`, which bumps `@ts-bridge/cli` to `0.4.0`.