### PR TITLE
Re-use existing default import for importing undetected named imports

### DIFF
--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -250,11 +250,9 @@ export function getNamedImportNodes(
   }
 
   const moduleSpecifier = getIdentifierName(node.moduleSpecifier.text);
-  const importIdentifier = getUniqueIdentifier(
-    typeChecker,
-    sourceFile,
-    moduleSpecifier,
-  );
+  const importIdentifier =
+    node.importClause.name?.text ??
+    getUniqueIdentifier(typeChecker, sourceFile, moduleSpecifier);
 
   const statements: Statement[] = [];
 

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -251,6 +251,8 @@ export function getNamedImportNodes(
 
   const moduleSpecifier = getIdentifierName(node.moduleSpecifier.text);
   const importIdentifier =
+    // If the import declaration has a name (default import), use that name, to
+    // avoid breaking the default import transformer.
     node.importClause.name?.text ??
     getUniqueIdentifier(typeChecker, sourceFile, moduleSpecifier);
 

--- a/packages/cli/src/transformers.test.ts
+++ b/packages/cli/src/transformers.test.ts
@@ -738,6 +738,21 @@ describe('getDefaultImportTransformer', () => {
       `);
     });
 
+    it('only rewrites default imports in combined imports', async () => {
+      expect(files['combined-imports.js']).toMatchInlineSnapshot(`
+        "function $importDefault(module) {
+            if (module?.__esModule) {
+                return module.default;
+            }
+            return module;
+        }
+        import $foo, { foo as bar } from 'commonjs-module';
+        const foo = $importDefault($foo);
+        console.log(foo, bar);
+        "
+      `);
+    });
+
     it('does not rewrite an invalid import', async () => {
       expect(files['invalid.js']).toMatchInlineSnapshot(`
         "// @ts-expect-error - Invalid module specifier.
@@ -807,6 +822,28 @@ describe('getNamedImportTransformer', () => {
         import $commonjsmodule from 'commonjs-module';
         const { bar: barImport } = $commonjsmodule;
         console.log(fooImport, barImport);
+        "
+      `);
+    });
+
+    it('uses an existing default import if it exists', () => {
+      expect(files['combined-imports.js']).toMatchInlineSnapshot(`
+        "import $foo from 'commonjs-module';
+        const { bar } = $foo;
+        /**
+         * Default import helper.
+         *
+         * @param module - Module with default export.
+         * @returns Default export.
+         */
+        function $importDefault(module) {
+            if (module?.__esModule) {
+                return module.default;
+            }
+            return module;
+        }
+        const foo = $importDefault($foo);
+        console.log(foo, bar);
         "
       `);
     });

--- a/packages/test-utils/test/fixtures/default-imports/src/combined-imports.ts
+++ b/packages/test-utils/test/fixtures/default-imports/src/combined-imports.ts
@@ -1,0 +1,3 @@
+import foo, { foo as bar } from 'commonjs-module';
+
+console.log(foo, bar);

--- a/packages/test-utils/test/fixtures/named-imports/src/combined-imports.ts
+++ b/packages/test-utils/test/fixtures/named-imports/src/combined-imports.ts
@@ -1,0 +1,17 @@
+import $foo, { bar } from 'commonjs-module';
+
+/**
+ * Default import helper.
+ *
+ * @param module - Module with default export.
+ * @returns Default export.
+ */
+function $importDefault(module: any): any {
+  if (module?.__esModule) {
+    return module.default;
+  }
+  return module;
+}
+
+const foo = $importDefault($foo);
+console.log(foo, bar);


### PR DESCRIPTION
This fixes a small bug introduced by #19. The following code for example:

```ts
import foo, { bar } from 'baz';
```

would be transformed by the default import transformer to:

```ts
import $foo, { bar } from 'baz';
const foo = $importDefault($foo);
```

but the named import transformer would then (assuming `bar` is an undetected import) transform it to:

```ts
import $baz from 'baz';
const { bar } = $baz;
const foo = $importDefault($foo);
```

where `$foo` now refers to an undeclared variable.

To fix it, I've simply updated the named import transformer to re-use the name of the default import if it exists. After this change, the code would be compiled like this instead:

```ts
import $foo from 'baz';
const { bar } = $foo;
const foo = $importDefault($foo);
```