### PR TITLE
Remove `require` from default conditions

### DIFF
--- a/packages/resolver/src/constants.ts
+++ b/packages/resolver/src/constants.ts
@@ -2,4 +2,4 @@
  * Default conditions for the resolver. These are the fields that are checked in
  * order to resolve an import from the `package.json` exports field.
  */
-export const DEFAULT_CONDITIONS = ['node', 'import', 'require'];
+export const DEFAULT_CONDITIONS = ['node', 'import'];


### PR DESCRIPTION
Apparently Node.js never uses `require` to resolve a module when running in ESM. This PR removes `require` from the list of conditions.