### PR TITLE
Release 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/root",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "private": true,
   "description": "The root package of the monorepo.",
   "homepage": "https://github.com/ts-bridge/ts-bridge#readme",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Re-use existing default import for importing undetected named imports ([#40](https://github.com/ts-bridge/ts-bridge/pull/40))
+
 ## [0.4.0]
 
 ### Added

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1]
 
-### Uncategorized
+### Fixed
 
 - Re-use existing default import for importing undetected named imports ([#40](https://github.com/ts-bridge/ts-bridge/pull/40))
+  - This fixes a bug where the default import was not properly replaced,
+    resulting in undefined variables.
 
 ## [0.4.0]
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1]
+
 ### Uncategorized
 
 - Re-use existing default import for importing undetected named imports ([#40](https://github.com/ts-bridge/ts-bridge/pull/40))
@@ -99,7 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/cli` package.
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.0...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.1...HEAD
+[0.4.1]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.0...@ts-bridge/cli@0.4.1
 [0.4.0]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.3.0...@ts-bridge/cli@0.4.0
 [0.3.0]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.2.0...@ts-bridge/cli@0.3.0
 [0.2.0]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.1.4...@ts-bridge/cli@0.2.0

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bridge the gap between ES modules and CommonJS modules with an easy-to-use alternative to `tsc`.",
   "keywords": [
     "build-tool",

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1]
+
 ### Uncategorized
 
 - Remove `require` from default conditions ([#41](https://github.com/ts-bridge/ts-bridge/pull/41))
@@ -17,5 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/resolver` package ([#20](https://github.com/ts-bridge/ts-bridge/pull/20), [#24](https://github.com/ts-bridge/ts-bridge/pull/24))
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.0...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.1...HEAD
+[0.1.1]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.0...@ts-bridge/resolver@0.1.1
 [0.1.0]: https://github.com/ts-bridge/ts-bridge/releases/tag/@ts-bridge/resolver@0.1.0

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1]
 
-### Uncategorized
+### Fixed
 
-- Remove `require` from default conditions ([#41](https://github.com/ts-bridge/ts-bridge/pull/41))
+- Remove `require` from default exports conditions ([#41](https://github.com/ts-bridge/ts-bridge/pull/41))
+  - Node.js does not use the `require` field when resolving CommonJS modules.
 
 ## [0.1.0]
 

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Remove `require` from default conditions ([#41](https://github.com/ts-bridge/ts-bridge/pull/41))
+
 ## [0.1.0]
 
 ### Added

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/resolver",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An implementation of the Node.js module resolution algorithm.",
   "keywords": [
     "build-tool",


### PR DESCRIPTION
This is the release candidate for version `9.0.0`. It bumps `@ts-bridge/cli` and `@ts-bridge/resolver` to fix some bugs.