### PR TITLE
Fix building subset of project references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,7 @@
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" vitest"
   },
   "dependencies": {
-    "@ts-bridge/resolver": "workspace:^",
+    "@ts-bridge/resolver": "^0.1.1",
     "chalk": "^5.3.0",
     "cjs-module-lexer": "^1.3.1",
     "yargs": "^17.7.2"

--- a/packages/cli/src/build.test.ts
+++ b/packages/cli/src/build.test.ts
@@ -395,6 +395,12 @@ describe('build', () => {
           'packages/project-2/dist/index.cjs',
           'packages/project-2/dist/index.d.cts.map',
           'packages/project-2/dist/index.d.cts',
+          'dist/index.mjs',
+          'dist/index.d.mts.map',
+          'dist/index.d.mts',
+          'dist/index.cjs',
+          'dist/index.d.cts.map',
+          'dist/index.d.cts',
         ]);
       });
 
@@ -462,6 +468,12 @@ describe('build', () => {
           'packages/project-2/dist/index.cjs',
           'packages/project-2/dist/index.d.cts.map',
           'packages/project-2/dist/index.d.cts',
+          'dist/index.mjs',
+          'dist/index.d.mts.map',
+          'dist/index.d.mts',
+          'dist/index.cjs',
+          'dist/index.d.cts.map',
+          'dist/index.d.cts',
         ]);
       });
     });

--- a/packages/test-utils/test/fixtures/project-references-node-10/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references-node-10/src/index.ts
@@ -1,0 +1,1 @@
+console.log('Hello, world!');

--- a/packages/test-utils/test/fixtures/project-references-node-10/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references-node-10/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "files": [],
+  "compilerOptions": {
+    "strictNullChecks": true
+  },
+  "include": ["src"],
   "references": [
     {
       "path": "./packages/project-1"

--- a/packages/test-utils/test/fixtures/project-references-node-16/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references-node-16/src/index.ts
@@ -1,0 +1,1 @@
+console.log('Hello, world!');

--- a/packages/test-utils/test/fixtures/project-references-node-16/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references-node-16/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "files": [],
+  "compilerOptions": {
+    "strictNullChecks": true
+  },
+  "include": ["src"],
   "references": [
     {
       "path": "./packages/project-1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,7 +1127,7 @@ __metadata:
   resolution: "@ts-bridge/cli@workspace:packages/cli"
   dependencies:
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@ts-bridge/resolver": "workspace:^"
+    "@ts-bridge/resolver": "npm:^0.1.1"
     "@ts-bridge/test-utils": "workspace:^"
     "@types/node": "npm:^20.12.7"
     "@types/yargs": "npm:^17.0.32"
@@ -1229,7 +1229,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ts-bridge/resolver@workspace:^, @ts-bridge/resolver@workspace:packages/resolver":
+"@ts-bridge/resolver@npm:^0.1.1, @ts-bridge/resolver@workspace:packages/resolver":
   version: 0.0.0-use.local
   resolution: "@ts-bridge/resolver@workspace:packages/resolver"
   dependencies:


### PR DESCRIPTION
This fixes building a subset of all project references. There are two changes:

- When creating the initial program and the `tsconfig.json` file contains project references, the project references compiler host will now be used here as well. This fixes errors like "File has not been built from source file".
- The main project will now be built as well, after all the referenced projects are built.