### PR TITLE
Forward verbose option to build function when building for Node 16

### DIFF
--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -362,14 +362,14 @@ export function buildNode16({
       name: 'Building ES module.',
       condition: () => format.includes('module'),
       task: () => {
-        build({ program, type: 'module', system, shims });
+        build({ program, type: 'module', system, shims, verbose });
       },
     },
     {
       name: 'Building CommonJS module.',
       condition: () => format.includes('commonjs'),
       task: () => {
-        build({ program, type: 'commonjs', system, shims });
+        build({ program, type: 'commonjs', system, shims, verbose });
       },
     },
   ];


### PR DESCRIPTION
When building for Node 16, the `verbose` option wouldn't be forwarded, so the logging output was different than Node 10.