### PR TITLE
Clean dist folders of referenced projects if `clean` is enabled

### DIFF
--- a/packages/cli/src/build.test.ts
+++ b/packages/cli/src/build.test.ts
@@ -477,6 +477,34 @@ describe('build', () => {
         ]);
       });
     });
+
+    it('removes the output directory of all referenced projects if `clean` is enabled', () => {
+      const path = getFixture('project-references-node-16');
+      const dist = join(path, 'dist');
+
+      compile(
+        getFixture('project-references-node-16'),
+        ['commonjs', 'module'],
+        {
+          references: true,
+          clean: true,
+        },
+      );
+
+      expect(vi.mocked(removeDirectory)).toHaveBeenCalledWith(dist, path);
+      expect(vi.mocked(removeDirectory)).toHaveBeenCalledWith(
+        join(path, 'packages/project-1/dist'),
+        join(path, 'packages/project-1'),
+      );
+      expect(vi.mocked(removeDirectory)).toHaveBeenCalledWith(
+        join(path, 'packages/project-2/dist'),
+        join(path, 'packages/project-2'),
+      );
+      expect(vi.mocked(removeDirectory)).toHaveBeenCalledWith(
+        join(path, 'packages/project-3/dist'),
+        join(path, 'packages/project-3'),
+      );
+    });
   });
 
   it('removes the output directory if `clean` is enabled', () => {

--- a/packages/cli/src/build.test.ts
+++ b/packages/cli/src/build.test.ts
@@ -508,14 +508,19 @@ describe('build', () => {
   });
 
   it('removes the output directory if `clean` is enabled', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(noOp);
     const path = getFixture('node-16');
     const dist = join(path, 'dist');
 
     compile(path, ['module'], {
       clean: true,
+      verbose: true,
     });
 
     expect(vi.mocked(removeDirectory)).toHaveBeenCalledWith(dist, path);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('Cleaning output directory'),
+    );
   });
 
   it('throws an error if the project fails to initialise', () => {

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -155,15 +155,17 @@ function getInitialCompilerHost({
  * @param project - The path to the project's `tsconfig.json` file.
  * @param options - The compiler options to use.
  * @param clean - Whether to clean the output directory before building.
+ * @param verbose - Whether to enable verbose logging.
  */
 function cleanOutputDirectory(
   project: string,
   options: CompilerOptions,
   clean = false,
+  verbose?: boolean,
 ) {
   const baseDirectory = dirname(project);
   if (clean && options.outDir) {
-    info(`Cleaning output directory "${options.outDir}".`);
+    verbose && info(`Cleaning output directory "${options.outDir}".`);
     removeDirectory(options.outDir, baseDirectory);
   }
 }
@@ -213,7 +215,7 @@ export function buildHandler(options: BuildHandlerOptions) {
   );
 
   const baseDirectory = dirname(project);
-  cleanOutputDirectory(project, baseOptions, clean);
+  cleanOutputDirectory(project, baseOptions, clean, verbose);
 
   const files = getFiles(customFiles, tsConfig.fileNames);
 
@@ -446,7 +448,7 @@ export function buildProjectReferences(options: BuilderOptions) {
       childOptions,
     );
 
-    cleanOutputDirectory(sourceFile.fileName, baseChildOptions, clean);
+    cleanOutputDirectory(sourceFile.fileName, baseChildOptions, clean, verbose);
 
     const compilerOptions = getCompilerOptions(baseChildOptions);
     const host = createProjectReferencesCompilerHost(

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -94,7 +94,7 @@ export function getTypeScriptConfig(path: string, system = sys) {
 export function getBaseCompilerOptions(
   basePath: string,
   baseOptions: CompilerOptions,
-) {
+): CompilerOptions {
   const fallbackPath = getAbsolutePath(basePath, 'dist');
 
   return {


### PR DESCRIPTION
If `--clean` was specified, only the parent project's `dist` folder would be removed. I've extracted the clean logic into a separate function and added a call for each referenced project, so each project will have its `dist` folder removed.