### PR TITLE
Resolve `index.js` file in `main` if `main` is a folder

### DIFF
--- a/packages/resolver/src/resolver.test.ts
+++ b/packages/resolver/src/resolver.test.ts
@@ -1033,6 +1033,43 @@ describe('resolve', () => {
       });
     });
 
+    it('resolves an external CommonJS package with a `main` field pointing to a directory containing an `index.js` file', () => {
+      const fileSystem = getFileSystem({
+        '/foo/node_modules/bar': { type: 'directory' },
+        '/foo/node_modules/bar/src': { type: 'directory' },
+        '/foo/node_modules/bar/src/index.js': 'console.log("hello!");',
+        '/foo/node_modules/bar/package.json': JSON.stringify({
+          name: 'bar',
+          main: 'src',
+        }),
+      });
+
+      expect(
+        resolve('bar', 'file:///foo/bar/baz.js', fileSystem, false),
+      ).toStrictEqual({
+        path: '/foo/node_modules/bar/src/index.js',
+        format: 'commonjs',
+      });
+    });
+
+    it('does not resolve an external CommonJS package with a `main` field pointing to a directory containing an `index.cjs` file', () => {
+      const fileSystem = getFileSystem({
+        '/foo/node_modules/bar': { type: 'directory' },
+        '/foo/node_modules/bar/src': { type: 'directory' },
+        '/foo/node_modules/bar/src/index.cjs': 'console.log("hello!");',
+        '/foo/node_modules/bar/package.json': JSON.stringify({
+          name: 'bar',
+          main: 'src',
+        }),
+      });
+
+      expect(() =>
+        resolve('bar', 'file:///foo/bar/baz.js', fileSystem, false),
+      ).toThrow(
+        'The package or module requested does not exist: "file:///foo/node_modules/bar/src/index.js".',
+      );
+    });
+
     it('does not resolve an external package without a `package.json`', () => {
       const fileSystem = getFileSystem({
         '/foo/node_modules/bar': { type: 'directory' },

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -776,6 +776,30 @@ function resolveSelf(
 }
 
 /**
+ * Resolve the `main` field of a `package.json` file. This function checks if
+ * the `main` field is a file or a directory, and returns the resolved URL. If
+ * it is a directory, it resolves the `index.js` file in the directory.
+ *
+ * @param packageUrl - The URL of the package.
+ * @param mainField - The value of the `main` field.
+ * @param fileSystem - The file system to use for resolution.
+ * @returns The resolved URL.
+ */
+function resolveMainField(
+  packageUrl: string,
+  mainField: string,
+  fileSystem: FileSystemInterface,
+): string {
+  if (fileSystem.isDirectory(resolvePath(packageUrl, mainField))) {
+    // If `main` is a folder, Node.js only resolves `index.js` in the folder. It
+    // does not resolve `index.cjs`.
+    return resolvePath(packageUrl, mainField, 'index.js');
+  }
+
+  return resolvePath(packageUrl, mainField);
+}
+
+/**
  * Resolve a package from the `node_modules` directory.
  *
  * This checks the current directory and all parent directories for the
@@ -818,7 +842,7 @@ function resolvePackageFromNodeModules(
         }
 
         if (packageSubpath === '.' && packageJson.main) {
-          return resolvePath(packageUrl, packageJson.main);
+          return resolveMainField(packageUrl, packageJson.main, fileSystem);
         }
 
         return resolvePath(packageUrl, packageSubpath);


### PR DESCRIPTION
This fixes support for resolving a package with the `main` field pointing to a folder, which will resolve the `index.js` in that folder.