### PR TITLE
Release 12.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/root",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "private": true,
   "description": "The root package of the monorepo.",
   "homepage": "https://github.com/ts-bridge/ts-bridge#readme",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4]
+
 ## [0.4.3]
 
 ### Fixed
@@ -116,7 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/cli` package.
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.3...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.4...HEAD
+[0.4.4]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.3...@ts-bridge/cli@0.4.4
 [0.4.3]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.2...@ts-bridge/cli@0.4.3
 [0.4.2]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.1...@ts-bridge/cli@0.4.2
 [0.4.1]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.0...@ts-bridge/cli@0.4.1

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.4]
 
+### Fixed
+
+- Resolve `index.js` file in `main` if `main` is a folder ([#48](https://github.com/ts-bridge/ts-bridge/pull/48))
+  - Accomplished by bumping `@ts-bridge/resolver` to `0.1.2`.
+
 ## [0.4.3]
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/cli",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Bridge the gap between ES modules and CommonJS modules with an easy-to-use alternative to `tsc`.",
   "keywords": [
     "build-tool",

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.2]
 
-### Uncategorized
+### Fixed
 
 - Resolve `index.js` file in `main` if `main` is a folder ([#48](https://github.com/ts-bridge/ts-bridge/pull/48))
 

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2]
+
 ### Uncategorized
 
 - Resolve `index.js` file in `main` if `main` is a folder ([#48](https://github.com/ts-bridge/ts-bridge/pull/48))
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/resolver` package ([#20](https://github.com/ts-bridge/ts-bridge/pull/20), [#24](https://github.com/ts-bridge/ts-bridge/pull/24))
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.1...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.2...HEAD
+[0.1.2]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.1...@ts-bridge/resolver@0.1.2
 [0.1.1]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.0...@ts-bridge/resolver@0.1.1
 [0.1.0]: https://github.com/ts-bridge/ts-bridge/releases/tag/@ts-bridge/resolver@0.1.0

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Resolve `index.js` file in `main` if `main` is a folder ([#48](https://github.com/ts-bridge/ts-bridge/pull/48))
+
 ## [0.1.1]
 
 ### Fixed

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/resolver",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An implementation of the Node.js module resolution algorithm.",
   "keywords": [
     "build-tool",


### PR DESCRIPTION
This is the release candidate for version `12.0.0`. It bumps `@ts-bridge/cli` and `@ts-bridge/resolver` to fix a small bug.