### PR TITLE
Fix detection of global symbols

### DIFF
--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -1,7 +1,6 @@
 import type {
   TypeChecker,
   Node,
-  Symbol,
   SourceFile,
   ImportDeclaration,
   Statement,
@@ -13,7 +12,7 @@ import type {
 import typescript from 'typescript';
 
 import { getCommonJsExports, isCommonJs } from './module-resolver.js';
-import { getIdentifierName } from './utils.js';
+import { getDefinedArray, getIdentifierName } from './utils.js';
 
 const {
   factory,
@@ -67,10 +66,16 @@ export function isGlobal(
     (symbol) =>
       symbol.escapedName === symbolName ||
       symbol.escapedName === `_${symbolName}`,
-    // eslint-disable-next-line @typescript-eslint/ban-types
-  ) as unknown as { parent?: Symbol };
+  );
 
-  return foundSymbol?.parent?.escapedName === '__global';
+  const declarations = getDefinedArray(foundSymbol?.getDeclarations());
+  for (const declaration of declarations) {
+    if (declaration.getSourceFile().isDeclarationFile) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
Looking at a symbol's parent (internal property) is not a reliable way to detect if something is global or not, resulting in false negatives in some cases. Looking at the declarations seems to be more reliable.