### PR TITLE
Add shim for `require.resolve`

### DIFF
--- a/docs/reference/shims.md
+++ b/docs/reference/shims.md
@@ -25,7 +25,7 @@ The following shims are available:
 - **For ESM environments**:
   - `__dirname`
   - `__filename`
-  - `require`
+  - `require` (and `require.resolve`)
 
 ## Example
 

--- a/packages/cli/src/shims.test.ts
+++ b/packages/cli/src/shims.test.ts
@@ -253,15 +253,12 @@ describe('getImportMetaUrlFunction', () => {
 
 describe('getRequireHelperFunction', () => {
   it('returns the `require` helper function', () => {
-    const ast = getRequireHelperFunction('createRequire');
+    const ast = getRequireHelperFunction('require', 'createRequire');
 
     expect(compile(ast)).toMatchInlineSnapshot(`
       ""use strict";
       import { createRequire as createRequire } from "module";
-      function require(identifier, url) {
-          const fn = createRequire(url);
-          return fn(identifier);
-      }
+      const require = createRequire(import.meta.url);
       "
     `);
   });
@@ -275,7 +272,7 @@ describe('getRequireHelperFunction', () => {
 
     beforeAll(async () => {
       const code = `
-        ${compile(getRequireHelperFunction('createRequire'))}
+        ${compile(getRequireHelperFunction('require', 'createRequire'))}
         export { require };
       `;
 

--- a/packages/cli/src/transformers.test.ts
+++ b/packages/cli/src/transformers.test.ts
@@ -639,12 +639,18 @@ describe('getRequireTransformer', () => {
     it('adds a shim when using `require`', async () => {
       expect(files['require.js']).toMatchInlineSnapshot(`
         "import { createRequire as $createRequire } from "module";
-        function require(identifier, url) {
-            const fn = $createRequire(url);
-            return fn(identifier);
-        }
-        const { builtinModules } = require('module', import.meta.url);
+        const $require = $createRequire(import.meta.url);
+        const { builtinModules } = $require('module');
         console.log(builtinModules);
+        "
+      `);
+    });
+
+    it('adds a shim when using `require.resolve`', async () => {
+      expect(files['require-resolve.js']).toMatchInlineSnapshot(`
+        "import { createRequire as $createRequire } from "module";
+        const $require = $createRequire(import.meta.url);
+        console.log($require.resolve('path/to/file.js'));
         "
       `);
     });

--- a/packages/test-utils/test/fixtures/globals/src/require-resolve.ts
+++ b/packages/test-utils/test/fixtures/globals/src/require-resolve.ts
@@ -1,0 +1,1 @@
+console.log(require.resolve('path/to/file.js'));


### PR DESCRIPTION
This adds a shim for `require.resolve`. To accomplish this, I've changed the existing require shim to create a global require function rather than creating a new function for every place where it's used. For example, the following code:

```ts
const path = require.resolve('foo');
```

will be transformed to:

```ts
import { createRequire as $createRequire } from 'module';

const $require = $createRequire(import.meta.url);
const path = $require.resolve('foo');
```