### PR TITLE
Release 13.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/root",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "private": true,
   "description": "The root package of the monorepo.",
   "homepage": "https://github.com/ts-bridge/ts-bridge#readme",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0]
 
-### Uncategorized
+### Added
+
+- Add shim for `require.resolve` ([#51](https://github.com/ts-bridge/ts-bridge/pull/51))
+  - This will replace `require.resolve` calls with an ESM-compatible version
+    when targeting ESM.
+
+### Fixed
 
 - Fix detection of global symbols ([#50](https://github.com/ts-bridge/ts-bridge/pull/50))
-- Add shim for `require.resolve` ([#51](https://github.com/ts-bridge/ts-bridge/pull/51))
 
 ## [0.4.4]
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0]
+
 ### Uncategorized
 
 - Fix detection of global symbols ([#50](https://github.com/ts-bridge/ts-bridge/pull/50))
@@ -128,7 +130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/cli` package.
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.4...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.5.0...HEAD
+[0.5.0]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.4...@ts-bridge/cli@0.5.0
 [0.4.4]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.3...@ts-bridge/cli@0.4.4
 [0.4.3]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.2...@ts-bridge/cli@0.4.3
 [0.4.2]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.1...@ts-bridge/cli@0.4.2

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Fix detection of global symbols ([#50](https://github.com/ts-bridge/ts-bridge/pull/50))
+- Add shim for `require.resolve` ([#51](https://github.com/ts-bridge/ts-bridge/pull/51))
+
 ## [0.4.4]
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/cli",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Bridge the gap between ES modules and CommonJS modules with an easy-to-use alternative to `tsc`.",
   "keywords": [
     "build-tool",


### PR DESCRIPTION
This is the release candidate for version `13.0.0`. It bumps `@ts-bridge/cli` to `0.5.0`, which adds a new shim and fixes a bug. See the changelog for more details.