### PR TITLE
Transform dynamic imports

### DIFF
--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -580,7 +580,7 @@ export function build({
 
   const { diagnostics } = program.emit(
     undefined,
-    getWriteFileFunction(type, system),
+    getWriteFileFunction(type, program.getCompilerOptions(), system, verbose),
     undefined,
     undefined,
     {

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -28,6 +28,7 @@ import type { Steps } from './steps.js';
 import { executeSteps } from './steps.js';
 import type { TransformerOptions } from './transformers.js';
 import {
+  getDynamicImportExtensionTransformer,
   getTypeImportExportTransformer,
   getExportExtensionTransformer,
   getImportExtensionTransformer,
@@ -587,12 +588,14 @@ export function build({
         getLoggingTransformer(verbose),
         getRequireExtensionTransformer(extension, options),
         getImportExtensionTransformer(extension, options),
+        getDynamicImportExtensionTransformer(extension, options),
         getExportExtensionTransformer(extension, options),
         getTypeImportExportTransformer(options),
         ...getTransformers(type, options, shims),
       ],
       afterDeclarations: [
         getImportExtensionTransformer(extension, options),
+        getDynamicImportExtensionTransformer(extension, options),
         getExportExtensionTransformer(extension, options),
       ],
     },

--- a/packages/cli/src/module-resolver.ts
+++ b/packages/cli/src/module-resolver.ts
@@ -184,6 +184,17 @@ export type GetModulePathOptions = {
 };
 
 /**
+ * Replace the extension of a path.
+ *
+ * @param path - The path to replace the extension of.
+ * @param extension - The new extension.
+ * @returns The path with the new extension.
+ */
+export function replaceExtension(path: string, extension: string) {
+  return path.replace(SOURCE_EXTENSIONS_REGEX, extension);
+}
+
+/**
  * Get the path to a module.
  *
  * @param options - The options for resolving the module.
@@ -215,7 +226,7 @@ export function getModulePath({
   }
 
   if (isRelative(packageSpecifier)) {
-    return resolution.specifier.replace(SOURCE_EXTENSIONS_REGEX, extension);
+    return replaceExtension(resolution.specifier, extension);
   }
 
   return resolution.specifier;

--- a/packages/cli/src/transformers.test.ts
+++ b/packages/cli/src/transformers.test.ts
@@ -1218,4 +1218,17 @@ describe('transformDeclarationImports', () => {
           "
     `);
   });
+
+  it('adds an extension to multiple relative dynamic imports on one line', () => {
+    const code = `
+      import("./dummy").Value; import("./folder").Value;
+    `;
+
+    expect(transformDeclarationImports(code, '.mjs', PARENT_URL, sys, false))
+      .toMatchInlineSnapshot(`
+        "
+              import("./dummy.mjs").Value; import("./folder/index.mjs").Value;
+            "
+      `);
+  });
 });

--- a/packages/cli/src/transformers.ts
+++ b/packages/cli/src/transformers.ts
@@ -975,7 +975,7 @@ function transformSourceMapUrl(
  * _import('./foo.js')
  * ```
  */
-const DYNAMIC_IMPORT_REGEX = /(?<![\w.])import\(['"](\..+)['"]\)/gu;
+const DYNAMIC_IMPORT_REGEX = /(?<![\w.])import\(['"](\..+?)['"]\)/gu;
 
 /**
  * Transform the dynamic imports in the declaration file to use the new file

--- a/packages/test-utils/test/fixtures/dynamic-imports/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/dynamic-imports/.eslintrc.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  extends: ['../../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+
+  overrides: [
+    {
+      files: ['*.ts'],
+      rules: {
+        '@typescript-eslint/no-unused-expressions': 'off',
+        'import-x/extensions': 'off',
+        'import-x/no-unassigned-import': 'off',
+      },
+    },
+  ],
+
+  ignorePatterns: ['**/invalid.ts'],
+};

--- a/packages/test-utils/test/fixtures/dynamic-imports/package.json
+++ b/packages/test-utils/test/fixtures/dynamic-imports/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@ts-bridge/dynamic-imports-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "semver": "^7.6.2"
+  }
+}

--- a/packages/test-utils/test/fixtures/dynamic-imports/src/add.ts
+++ b/packages/test-utils/test/fixtures/dynamic-imports/src/add.ts
@@ -1,0 +1,1 @@
+import('./dummy');

--- a/packages/test-utils/test/fixtures/dynamic-imports/src/declaration.ts
+++ b/packages/test-utils/test/fixtures/dynamic-imports/src/declaration.ts
@@ -1,0 +1,11 @@
+import { Foo } from './dummy';
+
+/**
+ * This function results in a case where TypeScript emits the declaration file
+ * with a dynamic import.
+ *
+ * @returns A class that extends `Foo`.
+ */
+export function bar() {
+  return class Bar extends Foo {};
+}

--- a/packages/test-utils/test/fixtures/dynamic-imports/src/dummy.ts
+++ b/packages/test-utils/test/fixtures/dynamic-imports/src/dummy.ts
@@ -1,0 +1,1 @@
+export const foo = 42;

--- a/packages/test-utils/test/fixtures/dynamic-imports/src/dummy.ts
+++ b/packages/test-utils/test/fixtures/dynamic-imports/src/dummy.ts
@@ -1,1 +1,13 @@
 export const foo = 42;
+
+export type Value = {
+  value: number;
+};
+
+export class Foo {
+  getValue(): Value {
+    return {
+      value: 0,
+    };
+  }
+}

--- a/packages/test-utils/test/fixtures/dynamic-imports/src/external.ts
+++ b/packages/test-utils/test/fixtures/dynamic-imports/src/external.ts
@@ -1,0 +1,2 @@
+import('semver');
+import('semver/preload.js');

--- a/packages/test-utils/test/fixtures/dynamic-imports/src/folder/index.ts
+++ b/packages/test-utils/test/fixtures/dynamic-imports/src/folder/index.ts
@@ -1,0 +1,1 @@
+export { foo } from '../dummy';

--- a/packages/test-utils/test/fixtures/dynamic-imports/src/import-folder.ts
+++ b/packages/test-utils/test/fixtures/dynamic-imports/src/import-folder.ts
@@ -1,0 +1,1 @@
+import('./folder');

--- a/packages/test-utils/test/fixtures/dynamic-imports/src/invalid.ts
+++ b/packages/test-utils/test/fixtures/dynamic-imports/src/invalid.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error - Invalid module specifier.
+import(0);

--- a/packages/test-utils/test/fixtures/dynamic-imports/src/override.ts
+++ b/packages/test-utils/test/fixtures/dynamic-imports/src/override.ts
@@ -1,0 +1,1 @@
+import('./dummy.js');

--- a/packages/test-utils/test/fixtures/dynamic-imports/src/unresolved.ts
+++ b/packages/test-utils/test/fixtures/dynamic-imports/src/unresolved.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error - Unresolved module.
+import('./unresolved-module');

--- a/packages/test-utils/test/fixtures/dynamic-imports/tsconfig.json
+++ b/packages/test-utils/test/fixtures/dynamic-imports/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,6 +1155,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ts-bridge/dynamic-imports-fixture@workspace:packages/test-utils/test/fixtures/dynamic-imports":
+  version: 0.0.0-use.local
+  resolution: "@ts-bridge/dynamic-imports-fixture@workspace:packages/test-utils/test/fixtures/dynamic-imports"
+  dependencies:
+    semver: "npm:^7.6.2"
+  languageName: unknown
+  linkType: soft
+
 "@ts-bridge/export-resolver-fixture@workspace:packages/test-utils/test/fixtures/export-resolver":
   version: 0.0.0-use.local
   resolution: "@ts-bridge/export-resolver-fixture@workspace:packages/test-utils/test/fixtures/export-resolver"


### PR DESCRIPTION
This adds a new transformer which transforms dynamic imports (`import(...)`). For example, the following code:

```ts
const foo = import('./foo');
```

is now transformed like so:

```ts
const foo = import('./foo.mjs'); // or `.cjs`
```