### PR TITLE
Add end-to-end tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -58,7 +58,7 @@ module.exports = {
     },
 
     {
-      files: ['*.test.ts', '*.test.js'],
+      files: ['*.test.ts', '*.e2e.ts'],
       extends: ['@metamask/eslint-config-nodejs'],
     },
 

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -35,6 +35,12 @@ jobs:
         run: yarn --immutable --immutable-cache
       - name: Build
         run: yarn build
+      - name: Create build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./packages/**/dist
+          key: build-${{ github.sha }}
       - name: Require clean working directory
         shell: bash
         run: |
@@ -88,6 +94,41 @@ jobs:
         run: yarn --immutable --immutable-cache
       - name: Test
         run: yarn test
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+
+  test-e2e:
+    name: End-to-end test
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./packages/**/dist
+          key: build-${{ github.sha }}
+          fail-on-cache-miss: true
+      - name: Install Yarn dependencies
+        run: yarn --immutable --immutable-cache
+      - name: End-to-end test
+        run: yarn test:e2e
       - name: Require clean working directory
         shell: bash
         run: |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,8 @@
     "allow-scripts": "yarn workspace @ts-bridge/root allow-scripts",
     "build": "tsc --project tsconfig.build.json",
     "lint:changelog": "../../scripts/validate-changelog.sh @ts-bridge/cli",
-    "test": "NODE_OPTIONS=\"--experimental-vm-modules\" vitest"
+    "test": "NODE_OPTIONS=\"--experimental-vm-modules\" vitest",
+    "test:e2e": "NODE_OPTIONS=\"--experimental-vm-modules\" vitest --config ./vitest.config.e2e.mts"
   },
   "dependencies": {
     "@ts-bridge/resolver": "workspace:^",

--- a/packages/cli/src/build-utils.ts
+++ b/packages/cli/src/build-utils.ts
@@ -227,6 +227,7 @@ export type BuilderOptions = {
  * @param options.shims - Whether to generate shims for environment-specific
  * APIs.
  * @param options.tsConfig - The TypeScript configuration.
+ * @param options.baseDirectory - The base directory of the project.
  */
 export function buildNode10({
   name,
@@ -239,6 +240,7 @@ export function buildNode10({
   verbose,
   shims,
   tsConfig,
+  baseDirectory,
 }: BuilderOptions) {
   const buildSteps: Steps<Record<string, never>> = [
     {
@@ -267,6 +269,7 @@ export function buildNode10({
           system,
           verbose,
           shims,
+          baseDirectory,
         });
       },
     },
@@ -296,6 +299,7 @@ export function buildNode10({
           system,
           verbose,
           shims,
+          baseDirectory,
         });
       },
     },
@@ -315,6 +319,7 @@ export function buildNode10({
  * @param options.verbose - Whether to enable verbose logging.
  * @param options.shims - Whether to generate shims for environment-specific
  * APIs.
+ * @param options.baseDirectory - The base directory of the project.
  */
 export function buildNode16({
   name,
@@ -323,20 +328,35 @@ export function buildNode16({
   system,
   verbose,
   shims,
+  baseDirectory,
 }: BuilderOptions) {
   const buildSteps: Steps<Record<string, never>> = [
     {
       name: `Building ES module "${name}".`,
       condition: () => format.includes('module'),
       task: () => {
-        build({ program, type: 'module', system, shims, verbose });
+        build({
+          program,
+          type: 'module',
+          system,
+          shims,
+          verbose,
+          baseDirectory,
+        });
       },
     },
     {
       name: `Building CommonJS module "${name}".`,
       condition: () => format.includes('commonjs'),
       task: () => {
-        build({ program, type: 'commonjs', system, shims, verbose });
+        build({
+          program,
+          type: 'commonjs',
+          system,
+          shims,
+          verbose,
+          baseDirectory,
+        });
       },
     },
   ];
@@ -449,6 +469,7 @@ type BuildOptions = {
   system: System;
   verbose?: boolean;
   shims: boolean;
+  baseDirectory: string;
 };
 
 /**
@@ -462,6 +483,7 @@ type BuildOptions = {
  * @param options.verbose - Whether to enable verbose logging.
  * @param options.shims - Whether to generate shims for environment-specific
  * APIs.
+ * @param options.baseDirectory - The base directory of the project.
  * @returns A promise that resolves when the build is complete.
  */
 export function build({
@@ -470,6 +492,7 @@ export function build({
   system,
   verbose,
   shims,
+  baseDirectory,
 }: BuildOptions): Program {
   const { name, extension } = getBuildTypeOptions(type);
 
@@ -485,7 +508,7 @@ export function build({
     undefined,
     {
       before: [
-        getLoggingTransformer(verbose),
+        getLoggingTransformer(baseDirectory, verbose),
         getRequireExtensionTransformer(extension, options),
         getImportExtensionTransformer(extension, options),
         getDynamicImportExtensionTransformer(extension, options),

--- a/packages/cli/src/cli.e2e.ts
+++ b/packages/cli/src/cli.e2e.ts
@@ -1,0 +1,321 @@
+import {
+  getFixture,
+  readAllDirectories,
+  removeDirectory,
+  run,
+} from '@ts-bridge/test-utils';
+import { readdir } from 'fs/promises';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('cli', () => {
+  describe('build', () => {
+    describe('node 10', () => {
+      beforeEach(async () => {
+        await removeDirectory(getFixture('node-10', 'dist'));
+      });
+
+      it('builds the project', async () => {
+        const runner = run('build', [], getFixture('node-10'));
+
+        const exitCode = await runner.wait();
+        expect(exitCode).toBe(0);
+        expect(runner.stdout).toHaveLength(0);
+        expect(runner.stderr).toHaveLength(0);
+
+        const files = await readdir(getFixture('node-10', 'dist'));
+        expect(files).toMatchInlineSnapshot(`
+          [
+            "file-1.cjs",
+            "file-1.cjs.map",
+            "file-1.d.cts",
+            "file-1.d.cts.map",
+            "file-1.d.mts",
+            "file-1.d.mts.map",
+            "file-1.mjs",
+            "file-1.mjs.map",
+            "file-2.cjs",
+            "file-2.cjs.map",
+            "file-2.d.cts",
+            "file-2.d.cts.map",
+            "file-2.d.mts",
+            "file-2.d.mts.map",
+            "file-2.mjs",
+            "file-2.mjs.map",
+            "index.cjs",
+            "index.cjs.map",
+            "index.d.cts",
+            "index.d.cts.map",
+            "index.d.mts",
+            "index.d.mts.map",
+            "index.mjs",
+            "index.mjs.map",
+          ]
+        `);
+      });
+
+      it('builds the project with verbose logging', async () => {
+        const runner = run('build', ['--verbose'], getFixture('node-10'));
+
+        const exitCode = await runner.wait();
+        expect(exitCode).toBe(0);
+        expect(runner.stderr).toHaveLength(0);
+        expect(runner.output).toMatchInlineSnapshot(`
+          "ℹ Building ES module "tsconfig.json".
+          → Transforming source file "src/file-1.ts".
+          → Transforming source file "src/file-2.ts".
+          → Transforming source file "src/index.ts".
+          ℹ Building CommonJS module "tsconfig.json".
+          → Transforming source file "src/file-1.ts".
+          → Transforming source file "src/file-2.ts".
+          → Transforming source file "src/index.ts".
+          ✔ Project built successfully.
+          "
+        `);
+      });
+    });
+
+    describe('node 16', () => {
+      beforeEach(async () => {
+        await removeDirectory(getFixture('node-16', 'dist'));
+      });
+
+      it('builds the project', async () => {
+        const runner = run('build', [], getFixture('node-16'));
+
+        const exitCode = await runner.wait();
+        expect(exitCode).toBe(0);
+        expect(runner.stdout).toHaveLength(0);
+        expect(runner.stderr).toHaveLength(0);
+
+        const files = await readdir(getFixture('node-16', 'dist'));
+        expect(files).toMatchInlineSnapshot(`
+          [
+            "file-1.cjs",
+            "file-1.cjs.map",
+            "file-1.d.cts",
+            "file-1.d.cts.map",
+            "file-1.d.mts",
+            "file-1.d.mts.map",
+            "file-1.mjs",
+            "file-1.mjs.map",
+            "file-2.cjs",
+            "file-2.cjs.map",
+            "file-2.d.cts",
+            "file-2.d.cts.map",
+            "file-2.d.mts",
+            "file-2.d.mts.map",
+            "file-2.mjs",
+            "file-2.mjs.map",
+            "index.cjs",
+            "index.cjs.map",
+            "index.d.cts",
+            "index.d.cts.map",
+            "index.d.mts",
+            "index.d.mts.map",
+            "index.mjs",
+            "index.mjs.map",
+          ]
+        `);
+      });
+
+      it('builds the project with verbose logging', async () => {
+        const runner = run('build', ['--verbose'], getFixture('node-16'));
+
+        const exitCode = await runner.wait();
+        expect(exitCode).toBe(0);
+        expect(runner.stderr).toHaveLength(0);
+        expect(runner.output).toMatchInlineSnapshot(`
+          "ℹ Building ES module "tsconfig.json".
+          → Transforming source file "src/file-1.ts".
+          → Transforming source file "src/file-2.ts".
+          → Transforming source file "src/index.ts".
+          ℹ Building CommonJS module "tsconfig.json".
+          → Transforming source file "src/file-1.ts".
+          → Transforming source file "src/file-2.ts".
+          → Transforming source file "src/index.ts".
+          ✔ Project built successfully.
+          "
+        `);
+      });
+    });
+
+    describe('project references', () => {
+      const FIXTURE_PATH = getFixture('project-references');
+      const FIXTURE_DIST_PATH = getFixture('project-references', 'dist');
+
+      const ALL_FIXTURE_DIST_PATHS = [
+        FIXTURE_DIST_PATH,
+        getFixture('project-references', 'packages', 'project-1', 'dist'),
+        getFixture('project-references', 'packages', 'project-2', 'dist'),
+        getFixture('project-references', 'packages', 'project-3', 'dist'),
+        getFixture('project-references', 'packages', 'project-4', 'dist'),
+        getFixture('project-references', 'packages', 'project-5', 'dist'),
+        getFixture('project-references', 'packages', 'project-6', 'dist'),
+      ];
+
+      beforeEach(async () => {
+        for (const path of ALL_FIXTURE_DIST_PATHS) {
+          await removeDirectory(path);
+        }
+      });
+
+      it('builds the project', async () => {
+        const runner = run('build', [], FIXTURE_PATH);
+
+        const exitCode = await runner.wait();
+        console.log(runner.output);
+        expect(exitCode).toBe(0);
+        expect(runner.stdout).toHaveLength(0);
+        expect(runner.stderr).toHaveLength(0);
+
+        const files = await readAllDirectories(
+          FIXTURE_PATH,
+          ALL_FIXTURE_DIST_PATHS,
+        );
+        expect(files).toMatchInlineSnapshot(`
+          [
+            "dist/index.cjs",
+            "dist/index.d.cts",
+            "dist/index.d.cts.map",
+            "dist/index.d.mts",
+            "dist/index.d.mts.map",
+            "dist/index.mjs",
+            "packages/project-1/dist/index.cjs",
+            "packages/project-1/dist/index.d.cts",
+            "packages/project-1/dist/index.d.cts.map",
+            "packages/project-1/dist/index.d.mts",
+            "packages/project-1/dist/index.d.mts.map",
+            "packages/project-1/dist/index.mjs",
+            "packages/project-2/dist/index.cjs",
+            "packages/project-2/dist/index.d.cts",
+            "packages/project-2/dist/index.d.cts.map",
+            "packages/project-2/dist/index.d.mts",
+            "packages/project-2/dist/index.d.mts.map",
+            "packages/project-2/dist/index.mjs",
+            "packages/project-3/dist/index.cjs",
+            "packages/project-3/dist/index.d.cts",
+            "packages/project-3/dist/index.d.cts.map",
+            "packages/project-3/dist/index.d.mts",
+            "packages/project-3/dist/index.d.mts.map",
+            "packages/project-3/dist/index.mjs",
+            "packages/project-4/dist/index.cjs",
+            "packages/project-4/dist/index.d.cts",
+            "packages/project-4/dist/index.d.cts.map",
+            "packages/project-4/dist/index.d.mts",
+            "packages/project-4/dist/index.d.mts.map",
+            "packages/project-4/dist/index.mjs",
+            "packages/project-5/dist/index.cjs",
+            "packages/project-5/dist/index.d.cts",
+            "packages/project-5/dist/index.d.cts.map",
+            "packages/project-5/dist/index.d.mts",
+            "packages/project-5/dist/index.d.mts.map",
+            "packages/project-5/dist/index.mjs",
+            "packages/project-6/dist/index.cjs",
+            "packages/project-6/dist/index.d.cts",
+            "packages/project-6/dist/index.d.cts.map",
+            "packages/project-6/dist/index.d.mts",
+            "packages/project-6/dist/index.d.mts.map",
+            "packages/project-6/dist/index.mjs",
+          ]
+        `);
+      });
+
+      it('builds the project with verbose logging', async () => {
+        const runner = run('build', ['--verbose'], FIXTURE_PATH);
+
+        const exitCode = await runner.wait();
+        expect(exitCode).toBe(0);
+        expect(runner.stderr).toHaveLength(0);
+
+        // Since we're working with worker threads, the order of the logs is not
+        // deterministic. We'll just check if the logs contain the expected
+        // messages.
+        expect(runner.output).toContain(
+          'Building ES module "packages/project-1/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building ES module "packages/project-2/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building ES module "packages/project-3/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building ES module "packages/project-4/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building ES module "packages/project-5/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building ES module "packages/project-6/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building CommonJS module "packages/project-1/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building CommonJS module "packages/project-2/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building CommonJS module "packages/project-3/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building CommonJS module "packages/project-4/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building CommonJS module "packages/project-5/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain(
+          'Building CommonJS module "packages/project-6/tsconfig.json"',
+        );
+
+        expect(runner.output).toContain('All project references built.');
+        expect(runner.output).toContain('Building ES module "tsconfig.json"');
+        expect(runner.output).toContain('Project built successfully.');
+      });
+    });
+  });
+
+  describe('--help', () => {
+    it('logs the manual', async () => {
+      const runner = run('build', ['--help']);
+
+      const manual = await runner.expectStdout();
+      const exitCode = await runner.wait();
+
+      expect(exitCode).toBe(0);
+      expect(manual).toMatchInlineSnapshot(`
+        "index.js build
+
+        Build the project using the TypeScript compiler. This is the default command.
+
+        Options:
+              --help                 Show help                                 [boolean]
+              --version              Show version number                       [boolean]
+          -p, --project              Path to the \`tsconfig.json\` file.
+                                                   [string] [default: "./tsconfig.json"]
+          -f, --format               The format(s) of the output files. Defaults to
+                                     \`module\` and \`commonjs\`.
+                [array] [choices: "module", "commonjs"] [default: ["module","commonjs"]]
+              --clean                Remove the output directory before building.
+                                                              [boolean] [default: false]
+              --verbose              Enable verbose logging.  [boolean] [default: false]
+              --references, --build  Build project references in the project. Enabled by
+                                     default if \`tsconfig.json\` contains project
+                                     references.               [boolean] [default: true]
+              --shims                Generate shims for environment-specific APIs.
+                                                               [boolean] [default: true]
+        "
+      `);
+    });
+  });
+});

--- a/packages/cli/src/cli.e2e.ts
+++ b/packages/cli/src/cli.e2e.ts
@@ -10,19 +10,22 @@ import { beforeEach, describe, expect, it } from 'vitest';
 describe('cli', () => {
   describe('build', () => {
     describe('node 10', () => {
+      const FIXTURE_PATH = getFixture('node-10');
+      const FIXTURE_DIST_PATH = getFixture('node-10', 'dist');
+
       beforeEach(async () => {
-        await removeDirectory(getFixture('node-10', 'dist'));
+        await removeDirectory(FIXTURE_DIST_PATH);
       });
 
       it('builds the project', async () => {
-        const runner = run('build', [], getFixture('node-10'));
+        const runner = run('build', [], FIXTURE_PATH);
 
         const exitCode = await runner.wait();
         expect(exitCode).toBe(0);
         expect(runner.stdout).toHaveLength(0);
         expect(runner.stderr).toHaveLength(0);
 
-        const files = await readdir(getFixture('node-10', 'dist'));
+        const files = await readdir(FIXTURE_DIST_PATH);
         expect(files).toMatchInlineSnapshot(`
           [
             "file-1.cjs",
@@ -54,7 +57,7 @@ describe('cli', () => {
       });
 
       it('builds the project with verbose logging', async () => {
-        const runner = run('build', ['--verbose'], getFixture('node-10'));
+        const runner = run('build', ['--verbose'], FIXTURE_PATH);
 
         const exitCode = await runner.wait();
         expect(exitCode).toBe(0);
@@ -75,19 +78,22 @@ describe('cli', () => {
     });
 
     describe('node 16', () => {
+      const FIXTURE_PATH = getFixture('node-16');
+      const FIXTURE_DIST_PATH = getFixture('node-16', 'dist');
+
       beforeEach(async () => {
-        await removeDirectory(getFixture('node-16', 'dist'));
+        await removeDirectory(FIXTURE_DIST_PATH);
       });
 
       it('builds the project', async () => {
-        const runner = run('build', [], getFixture('node-16'));
+        const runner = run('build', [], FIXTURE_PATH);
 
         const exitCode = await runner.wait();
         expect(exitCode).toBe(0);
         expect(runner.stdout).toHaveLength(0);
         expect(runner.stderr).toHaveLength(0);
 
-        const files = await readdir(getFixture('node-16', 'dist'));
+        const files = await readdir(FIXTURE_DIST_PATH);
         expect(files).toMatchInlineSnapshot(`
           [
             "file-1.cjs",
@@ -119,7 +125,7 @@ describe('cli', () => {
       });
 
       it('builds the project with verbose logging', async () => {
-        const runner = run('build', ['--verbose'], getFixture('node-16'));
+        const runner = run('build', ['--verbose'], FIXTURE_PATH);
 
         const exitCode = await runner.wait();
         expect(exitCode).toBe(0);
@@ -163,7 +169,6 @@ describe('cli', () => {
         const runner = run('build', [], FIXTURE_PATH);
 
         const exitCode = await runner.wait();
-        console.log(runner.output);
         expect(exitCode).toBe(0);
         expect(runner.stdout).toHaveLength(0);
         expect(runner.stderr).toHaveLength(0);

--- a/packages/cli/src/cli.e2e.ts
+++ b/packages/cli/src/cli.e2e.ts
@@ -1,6 +1,6 @@
 import {
   getFixture,
-  readAllDirectories,
+  readDirectories,
   removeDirectory,
   run,
 } from '@ts-bridge/test-utils';
@@ -173,7 +173,7 @@ describe('cli', () => {
         expect(runner.stdout).toHaveLength(0);
         expect(runner.stderr).toHaveLength(0);
 
-        const files = await readAllDirectories(
+        const files = await readDirectories(
           FIXTURE_PATH,
           ALL_FIXTURE_DIST_PATHS,
         );

--- a/packages/cli/src/cli.e2e.ts
+++ b/packages/cli/src/cli.e2e.ts
@@ -20,7 +20,7 @@ describe('cli', () => {
       it('builds the project', async () => {
         const runner = run('build', [], FIXTURE_PATH);
 
-        const exitCode = await runner.wait();
+        const exitCode = await runner.waitForExit();
         expect(exitCode).toBe(0);
         expect(runner.stdout).toHaveLength(0);
         expect(runner.stderr).toHaveLength(0);
@@ -59,7 +59,7 @@ describe('cli', () => {
       it('builds the project with verbose logging', async () => {
         const runner = run('build', ['--verbose'], FIXTURE_PATH);
 
-        const exitCode = await runner.wait();
+        const exitCode = await runner.waitForExit();
         expect(exitCode).toBe(0);
         expect(runner.stderr).toHaveLength(0);
         expect(runner.output).toMatchInlineSnapshot(`
@@ -88,7 +88,7 @@ describe('cli', () => {
       it('builds the project', async () => {
         const runner = run('build', [], FIXTURE_PATH);
 
-        const exitCode = await runner.wait();
+        const exitCode = await runner.waitForExit();
         expect(exitCode).toBe(0);
         expect(runner.stdout).toHaveLength(0);
         expect(runner.stderr).toHaveLength(0);
@@ -127,7 +127,7 @@ describe('cli', () => {
       it('builds the project with verbose logging', async () => {
         const runner = run('build', ['--verbose'], FIXTURE_PATH);
 
-        const exitCode = await runner.wait();
+        const exitCode = await runner.waitForExit();
         expect(exitCode).toBe(0);
         expect(runner.stderr).toHaveLength(0);
         expect(runner.output).toMatchInlineSnapshot(`
@@ -168,7 +168,7 @@ describe('cli', () => {
       it('builds the project', async () => {
         const runner = run('build', [], FIXTURE_PATH);
 
-        const exitCode = await runner.wait();
+        const exitCode = await runner.waitForExit();
         expect(exitCode).toBe(0);
         expect(runner.stdout).toHaveLength(0);
         expect(runner.stderr).toHaveLength(0);
@@ -228,7 +228,7 @@ describe('cli', () => {
       it('builds the project with verbose logging', async () => {
         const runner = run('build', ['--verbose'], FIXTURE_PATH);
 
-        const exitCode = await runner.wait();
+        const exitCode = await runner.waitForExit();
         expect(exitCode).toBe(0);
         expect(runner.stderr).toHaveLength(0);
 
@@ -295,7 +295,7 @@ describe('cli', () => {
       const runner = run('build', ['--help']);
 
       const manual = await runner.expectStdout();
-      const exitCode = await runner.wait();
+      const exitCode = await runner.waitForExit();
 
       expect(exitCode).toBe(0);
       expect(manual).toMatchInlineSnapshot(`

--- a/packages/cli/src/logging.test.ts
+++ b/packages/cli/src/logging.test.ts
@@ -23,7 +23,7 @@ describe('getLoggingTransformer', () => {
   it('logs the current file when verbose is enabled', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(noOp);
 
-    const transformer = getLoggingTransformer(true)();
+    const transformer = getLoggingTransformer(import.meta.dirname, true)();
     const sourceFile = { fileName: 'file.ts' };
 
     // @ts-expect-error - Partial source file.
@@ -36,7 +36,7 @@ describe('getLoggingTransformer', () => {
   it('does not log the current file when verbose is disabled', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(noOp);
 
-    const transformer = getLoggingTransformer(false)();
+    const transformer = getLoggingTransformer(import.meta.dirname, false)();
     const sourceFile = { fileName: 'file.ts' };
 
     // @ts-expect-error - Partial source file.

--- a/packages/cli/src/logging.ts
+++ b/packages/cli/src/logging.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { relative } from 'path';
 import type { SourceFile, Transformer } from 'typescript';
 
 /**
@@ -76,15 +77,21 @@ export function log(message: string) {
  * This transformer does not actually transform the source file. It just uses
  * TypeScript's transformer API to check which files are being transformed.
  *
+ * @param baseDirectory - The base directory of the project.
  * @param verbose - Whether to enable verbose logging.
  * @returns The transformer function.
  */
-export function getLoggingTransformer(verbose?: boolean) {
+export function getLoggingTransformer(
+  baseDirectory: string,
+  verbose?: boolean,
+) {
   return (): Transformer<SourceFile> => {
     return (sourceFile: SourceFile) => {
       verbose &&
         log(
-          `Transforming source file "${chalk.underline(sourceFile.fileName)}".`,
+          `Transforming source file "${chalk.underline(
+            relative(baseDirectory, sourceFile.fileName),
+          )}".`,
         );
 
       return sourceFile;

--- a/packages/cli/vitest.config.e2e.mts
+++ b/packages/cli/vitest.config.e2e.mts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.e2e.ts'],
     watch: false,
     testTimeout: 30000,
   },

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -35,7 +35,8 @@
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" vitest"
   },
   "dependencies": {
-    "@typescript/vfs": "^1.5.0"
+    "@typescript/vfs": "^1.5.0",
+    "strip-ansi": "^7.1.0"
   },
   "devDependencies": {
     "@types/lz-string": "^1.5.0",

--- a/packages/test-utils/src/e2e.ts
+++ b/packages/test-utils/src/e2e.ts
@@ -1,0 +1,242 @@
+import assert from 'assert';
+import type { ChildProcess } from 'child_process';
+import { spawn } from 'child_process';
+import EventEmitter from 'events';
+import { join } from 'path';
+import stripAnsi from 'strip-ansi';
+import { fileURLToPath } from 'url';
+
+import { delay } from './delay.js';
+
+/**
+ * A test runner for running CLI commands. It keeps track of the stdout and
+ * stderr of the process, and emits events when new data is written to stdout or
+ * stderr.
+ */
+class CommandLineRunner extends EventEmitter {
+  readonly #process: ChildProcess;
+
+  readonly stdout: string[] = [];
+
+  readonly stderr: string[] = [];
+
+  readonly #defaultTimeout: number;
+
+  #output = '';
+
+  #exitCode?: number | null = null;
+
+  constructor(
+    command: string,
+    options: string[],
+    workingDirectory: string = process.cwd(),
+    defaultTimeout = 30000,
+  ) {
+    super();
+
+    this.#defaultTimeout = defaultTimeout;
+    this.#process = spawn(command, options, {
+      cwd: workingDirectory,
+      stdio: 'pipe',
+    });
+
+    this.#process.stdout?.on('data', (data) => {
+      const string = data.toString();
+      this.#output += string;
+
+      this.stdout.push(string);
+      this.emit('stdout', string);
+    });
+
+    this.#process.stderr?.on('data', (data) => {
+      const string = data.toString();
+      this.#output += string;
+
+      this.stderr.push(string);
+      this.emit('stderr', string);
+    });
+
+    this.#process.on('exit', (exitCode) => {
+      this.#exitCode = exitCode;
+      this.emit('exit', exitCode);
+    });
+  }
+
+  /**
+   * Whether the process is running.
+   *
+   * @returns `true` if the process is running, otherwise `false`.
+   */
+  get running() {
+    return this.#exitCode === null;
+  }
+
+  /**
+   * The output of the command, without ANSI escape codes.
+   *
+   * @returns The output of the command.
+   */
+  get output() {
+    return stripAnsi(this.#output);
+  }
+
+  /**
+   * Kill the process. If the process is already dead, this does nothing.
+   *
+   * @param signal - The signal to send to the process.
+   */
+  kill(signal?: NodeJS.Signals) {
+    if (!this.running) {
+      return;
+    }
+
+    this.#process.kill(signal);
+  }
+
+  /**
+   * Wait for the process to exit.
+   *
+   * @returns The exit code.
+   */
+  async wait() {
+    if (!this.running) {
+      return this.#exitCode;
+    }
+
+    return new Promise<number | null>((resolve) => {
+      this.#process.on('exit', (exitCode) => {
+        resolve(exitCode);
+      });
+    });
+  }
+
+  /**
+   * Wait for a message to be written to stdout.
+   *
+   * @param message - The message to wait for. If a string, the message must be
+   * contained in the stdout. If a regular expression, the message must match
+   * the stdout.
+   * @param timeout - How long to wait for the message. If the message is not
+   * written to stdout within this time, an error is thrown.
+   * @returns The message that was written to stdout.
+   */
+  async expectStdout(
+    message?: string | RegExp,
+    timeout = this.#defaultTimeout,
+  ) {
+    assert(
+      this.running,
+      'Cannot wait for stdout while process is not running.',
+    );
+
+    const promise = new Promise<string>((resolve) => {
+      const listener = (actual: string) => {
+        if (this.#matches(message, actual)) {
+          this.off('stdout', listener);
+          resolve(actual);
+        }
+      };
+
+      this.on('stdout', listener);
+    });
+
+    return await Promise.race([
+      promise,
+      this.#timeout(timeout, `Timed out waiting for stdout.`),
+    ]);
+  }
+
+  /**
+   * Wait for a message to be written to stderr.
+   *
+   * @param message - The message to wait for. If a string, the message must be
+   * contained in the stderr. If a regular expression, the message must match
+   * the stderr.
+   * @param timeout - How long to wait for the message. If the message is not
+   * written to stdout within this time, an error is thrown.
+   * @returns The message that was written to stderr.
+   */
+  async expectStderr(
+    message?: string | RegExp,
+    timeout = this.#defaultTimeout,
+  ) {
+    assert(
+      this.running,
+      'Cannot wait for stderr while process is not running.',
+    );
+
+    const promise = new Promise<string>((resolve) => {
+      const listener = (actual: string) => {
+        if (this.#matches(message, actual)) {
+          this.off('stderr', listener);
+          resolve(actual);
+        }
+      };
+
+      this.on('stderr', listener);
+    });
+
+    return await Promise.race([
+      promise,
+      this.#timeout(timeout, `Timed out waiting for stderr.`),
+    ]);
+  }
+
+  /**
+   * Check if `expected` matches `actual`.
+   *
+   * @param expected - The expected message.
+   * @param actual - The actual message.
+   * @returns `true` if `expected` matches `actual`, otherwise `false`.
+   */
+  #matches(expected: string | RegExp | undefined, actual: string) {
+    if (expected === undefined) {
+      return true;
+    }
+
+    if (typeof expected === 'string') {
+      return actual.includes(expected);
+    }
+
+    return expected.test(actual);
+  }
+
+  async #timeout(timeout: number, message: string) {
+    await delay(timeout);
+
+    this.kill('SIGKILL');
+    throw new Error(message);
+  }
+}
+
+/**
+ * Get a command runner.
+ *
+ * @param command - The `ts-bridge` CLI command to run.
+ * @param options - The options to pass to `ts-bridge`.
+ * @param workingDirectory - The working directory to run the command in.
+ * @returns The test runner.
+ */
+export function run(
+  command: string,
+  options: string[] = [],
+  workingDirectory: string = process.cwd(),
+) {
+  return new CommandLineRunner(
+    'node',
+    [
+      join(
+        fileURLToPath(import.meta.url),
+        '..',
+        '..',
+        '..',
+        'cli',
+        'dist',
+        'index.js',
+      ),
+      command,
+      ...options,
+    ],
+    workingDirectory,
+  );
+}

--- a/packages/test-utils/src/e2e.ts
+++ b/packages/test-utils/src/e2e.ts
@@ -98,7 +98,7 @@ class CommandLineRunner extends EventEmitter {
    *
    * @returns The exit code.
    */
-  async wait() {
+  async waitForExit() {
     if (!this.running) {
       return this.#exitCode;
     }

--- a/packages/test-utils/src/file-system.ts
+++ b/packages/test-utils/src/file-system.ts
@@ -124,13 +124,13 @@ export async function removeDirectory(path: string) {
 }
 
 /**
- * Read all entries in the given directories.
+ * Read all entries in the given directories, non-recursively.
  *
  * @param baseDirectory - The base directory of the directories.
  * @param directories - The directories to read.
  * @returns The entries in the directories.
  */
-export async function readAllDirectories(
+export async function readDirectories(
   baseDirectory: string,
   directories: string[],
 ) {

--- a/packages/test-utils/src/file-system.ts
+++ b/packages/test-utils/src/file-system.ts
@@ -112,12 +112,11 @@ export async function removeDirectory(path: string) {
     await rm(path, { recursive: true });
   } catch (error) {
     if (
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
+      typeof error !== 'object' ||
+      error === null ||
+      !('code' in error) ||
       error.code !== 'ENOENT'
     ) {
-      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw error;
     }
   }

--- a/packages/test-utils/src/file-system.ts
+++ b/packages/test-utils/src/file-system.ts
@@ -1,4 +1,5 @@
-import { resolve as resolvePath } from 'path';
+import { readdir, rm } from 'fs/promises';
+import { join, relative, resolve as resolvePath } from 'path';
 import { fileURLToPath } from 'url';
 
 type FileEntry = {
@@ -98,4 +99,49 @@ const ROOT_PATH = resolvePath(fileURLToPath(import.meta.url), '../../../..');
  */
 export function getPathFromRoot(path: string): string {
   return resolvePath(ROOT_PATH, path);
+}
+
+/**
+ * Remove a directory and all its contents.
+ *
+ * @param path - The path to the directory to remove.
+ * @throws If the directory cannot be removed.
+ */
+export async function removeDirectory(path: string) {
+  try {
+    await rm(path, { recursive: true });
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code !== 'ENOENT'
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw error;
+    }
+  }
+}
+
+/**
+ * Read all entries in the given directories.
+ *
+ * @param baseDirectory - The base directory of the directories.
+ * @param directories - The directories to read.
+ * @returns The entries in the directories.
+ */
+export async function readAllDirectories(
+  baseDirectory: string,
+  directories: string[],
+) {
+  const entries: string[] = [];
+  for (const directory of directories) {
+    const entriesInDirectory = await readdir(directory);
+
+    entriesInDirectory
+      .map((entry) => relative(baseDirectory, join(directory, entry)))
+      .forEach((entry) => entries.push(entry));
+  }
+
+  return entries;
 }

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from './delay.js';
+export * from './e2e.js';
 export * from './evaluate.js';
 export * from './file-system.js';
 export * from './fixtures.js';

--- a/packages/test-utils/test/fixtures/project-references/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  extends: ['../../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+
+  overrides: [
+    {
+      files: ['*.ts'],
+      rules: {
+        'import-x/extensions': 'off',
+      },
+    },
+  ],
+};

--- a/packages/test-utils/test/fixtures/project-references/README.md
+++ b/packages/test-utils/test/fixtures/project-references/README.md
@@ -7,7 +7,7 @@ graph is as follows:
 ```mermaid
 %%{
   init: {
-	  "flowchart": {
+    "flowchart": {
       "curve": "bumpX"
     }
   }

--- a/packages/test-utils/test/fixtures/project-references/README.md
+++ b/packages/test-utils/test/fixtures/project-references/README.md
@@ -1,0 +1,28 @@
+# Project references test
+
+This folder contains a project with project references. It's used for end-to-end
+testing of the project references parallelisation functionality. The dependency
+graph is as follows:
+
+```mermaid
+%%{
+  init: {
+	  "flowchart": {
+      "curve": "bumpX"
+    }
+  }
+}%%
+
+graph LR;
+    project-1(["Project 1"])
+    project-2(["Project 2"])
+    project-3(["Project 3"])
+    project-4(["Project 4"])
+    project-5(["Project 5"])
+    project-6(["Project 6"])
+
+    project-2 --> project-1
+    project-3 --> project-1
+    project-4 --> project-2
+    project-5 --> project-2
+```

--- a/packages/test-utils/test/fixtures/project-references/package.json
+++ b/packages/test-utils/test/fixtures/project-references/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@ts-bridge/project-references-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-1/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-1/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/test-utils/test/fixtures/project-references/packages/project-1/package.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@project-references-test/project-1",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts"
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-1/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-1/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = 42;

--- a/packages/test-utils/test/fixtures/project-references/packages/project-1/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-1/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Node",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "typeRoots": []
+  },
+  "include": ["src"]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-2/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-2/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/test-utils/test/fixtures/project-references/packages/project-2/package.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@project-references-test/project-2",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "dependencies": {
+    "@project-references-test/project-1": "workspace:^"
+  }
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-2/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-2/src/index.ts
@@ -1,0 +1,3 @@
+import { foo } from '@project-references-test/project-1';
+
+export { foo };

--- a/packages/test-utils/test/fixtures/project-references/packages/project-2/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-2/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "typeRoots": []
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../project-1"
+    }
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-3/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-3/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/test-utils/test/fixtures/project-references/packages/project-3/package.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-3/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@project-references-test/project-3",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "dependencies": {
+    "@project-references-test/project-1": "workspace:^"
+  }
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-3/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-3/src/index.ts
@@ -1,0 +1,3 @@
+import { foo } from '@project-references-test/project-1';
+
+export { foo };

--- a/packages/test-utils/test/fixtures/project-references/packages/project-3/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-3/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "typeRoots": []
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../project-1"
+    }
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-4/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-4/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/test-utils/test/fixtures/project-references/packages/project-4/package.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-4/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@project-references-test/project-4",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "dependencies": {
+    "@project-references-test/project-2": "workspace:^"
+  }
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-4/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-4/src/index.ts
@@ -1,0 +1,3 @@
+import { foo } from '@project-references-test/project-2';
+
+export { foo };

--- a/packages/test-utils/test/fixtures/project-references/packages/project-4/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-4/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Node",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "typeRoots": []
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../project-2"
+    }
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-5/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-5/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/test-utils/test/fixtures/project-references/packages/project-5/package.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-5/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@project-references-test/project-5",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "dependencies": {
+    "@project-references-test/project-2": "workspace:^"
+  }
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-5/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-5/src/index.ts
@@ -1,0 +1,3 @@
+import { foo } from '@project-references-test/project-2';
+
+export { foo };

--- a/packages/test-utils/test/fixtures/project-references/packages/project-5/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-5/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "typeRoots": []
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../project-2"
+    }
+  ]
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-6/.eslintrc.cjs
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-6/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/test-utils/test/fixtures/project-references/packages/project-6/package.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-6/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@project-references-test/project-6",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts"
+}

--- a/packages/test-utils/test/fixtures/project-references/packages/project-6/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-6/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = 42;

--- a/packages/test-utils/test/fixtures/project-references/packages/project-6/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/packages/project-6/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "paths": {
+      "@project-references-test/*": ["../*/src"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "typeRoots": []
+  },
+  "include": ["src"]
+}

--- a/packages/test-utils/test/fixtures/project-references/src/index.ts
+++ b/packages/test-utils/test/fixtures/project-references/src/index.ts
@@ -1,0 +1,1 @@
+console.log('Hello, world!');

--- a/packages/test-utils/test/fixtures/project-references/tsconfig.json
+++ b/packages/test-utils/test/fixtures/project-references/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "strictNullChecks": true
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "./packages/project-1"
+    },
+    {
+      "path": "./packages/project-2"
+    },
+    {
+      "path": "./packages/project-3"
+    },
+    {
+      "path": "./packages/project-4"
+    },
+    {
+      "path": "./packages/project-5"
+    },
+    {
+      "path": "./packages/project-6"
+    }
+  ]
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,7 +17,7 @@ export default defineConfig({
       include: ['packages/*/src/**'],
 
       // Exclude certain files from the coverage.
-      exclude: ['packages/test-utils/**'],
+      exclude: ['packages/test-utils/**', '**/*.e2e.ts'],
 
       // Hide files with 100% coverage.
       skipFull: true,

--- a/vitest.workspace.mts
+++ b/vitest.workspace.mts
@@ -1,3 +1,6 @@
 import { defineWorkspace } from 'vitest/config';
 
-export default defineWorkspace(['packages/*']);
+export default defineWorkspace([
+  'packages/*/vitest.config.mts',
+  // 'packages/*/vitest.config.e2e.mts',
+]);

--- a/vitest.workspace.mts
+++ b/vitest.workspace.mts
@@ -1,6 +1,3 @@
 import { defineWorkspace } from 'vitest/config';
 
-export default defineWorkspace([
-  'packages/*/vitest.config.mts',
-  // 'packages/*/vitest.config.e2e.mts',
-]);
+export default defineWorkspace(['packages/*/vitest.config.mts']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,6 +1174,50 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@project-references-test/project-1@workspace:^, @project-references-test/project-1@workspace:packages/test-utils/test/fixtures/project-references/packages/project-1":
+  version: 0.0.0-use.local
+  resolution: "@project-references-test/project-1@workspace:packages/test-utils/test/fixtures/project-references/packages/project-1"
+  languageName: unknown
+  linkType: soft
+
+"@project-references-test/project-2@workspace:^, @project-references-test/project-2@workspace:packages/test-utils/test/fixtures/project-references/packages/project-2":
+  version: 0.0.0-use.local
+  resolution: "@project-references-test/project-2@workspace:packages/test-utils/test/fixtures/project-references/packages/project-2"
+  dependencies:
+    "@project-references-test/project-1": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
+"@project-references-test/project-3@workspace:packages/test-utils/test/fixtures/project-references/packages/project-3":
+  version: 0.0.0-use.local
+  resolution: "@project-references-test/project-3@workspace:packages/test-utils/test/fixtures/project-references/packages/project-3"
+  dependencies:
+    "@project-references-test/project-1": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
+"@project-references-test/project-4@workspace:packages/test-utils/test/fixtures/project-references/packages/project-4":
+  version: 0.0.0-use.local
+  resolution: "@project-references-test/project-4@workspace:packages/test-utils/test/fixtures/project-references/packages/project-4"
+  dependencies:
+    "@project-references-test/project-2": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
+"@project-references-test/project-5@workspace:packages/test-utils/test/fixtures/project-references/packages/project-5":
+  version: 0.0.0-use.local
+  resolution: "@project-references-test/project-5@workspace:packages/test-utils/test/fixtures/project-references/packages/project-5"
+  dependencies:
+    "@project-references-test/project-2": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
+"@project-references-test/project-6@workspace:packages/test-utils/test/fixtures/project-references/packages/project-6":
+  version: 0.0.0-use.local
+  resolution: "@project-references-test/project-6@workspace:packages/test-utils/test/fixtures/project-references/packages/project-6"
+  languageName: unknown
+  linkType: soft
+
 "@rollup/rollup-android-arm-eabi@npm:4.14.1":
   version: 4.14.1
   resolution: "@rollup/rollup-android-arm-eabi@npm:4.14.1"
@@ -1411,6 +1455,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ts-bridge/project-references-fixture@workspace:packages/test-utils/test/fixtures/project-references":
+  version: 0.0.0-use.local
+  resolution: "@ts-bridge/project-references-fixture@workspace:packages/test-utils/test/fixtures/project-references"
+  languageName: unknown
+  linkType: soft
+
 "@ts-bridge/project-references-node-10-fixture@workspace:packages/test-utils/test/fixtures/project-references-node-10":
   version: 0.0.0-use.local
   resolution: "@ts-bridge/project-references-node-10-fixture@workspace:packages/test-utils/test/fixtures/project-references-node-10"
@@ -1484,6 +1534,7 @@ __metadata:
     "@types/lz-string": "npm:^1.5.0"
     "@types/node": "npm:^20.12.7"
     "@typescript/vfs": "npm:^1.5.0"
+    strip-ansi: "npm:^7.1.0"
     typescript: "npm:^5.4.5"
     vitest: "npm:^1.5.0"
   languageName: unknown


### PR DESCRIPTION
This adds end-to-end tests for the build functionality. It covers Node 10 and Node 16 module resolution, as well as a project with references, and a slightly more complex dependency graph than the current projects. To accomplish this, I've added a simple command runner class which runs the CLI in a separate process and listens to `stdout` and `stderr`.

The end-to-end tests run on the dist files, so building the project is required for it to work. I've added a step in CI that waits for the build step to complete, and uses the cached dist files from there.

The new project references fixture uses both Node 10 and Node 16 module resolution, ensuring that they can be combined.

Closes #60.