### PR TITLE
Remove test files from dist

### DIFF
--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -7,7 +7,8 @@
     "rootDir": "./src",
     "tsBuildInfoFile": ".tsbuildinfo"
   },
-  "include": ["src"],
+  "include": ["./src"],
+  "exclude": ["**/*.test.ts", "**/*.e2e.ts"],
   "references": [
     {
       "path": "../resolver/tsconfig.build.json"

--- a/packages/resolver/tsconfig.build.json
+++ b/packages/resolver/tsconfig.build.json
@@ -7,7 +7,8 @@
     "rootDir": "./src",
     "tsBuildInfoFile": ".tsbuildinfo"
   },
-  "include": ["src"],
+  "include": ["./src"],
+  "exclude": ["**/*.test.ts", "**/*.e2e.ts"],
   "references": [
     {
       "path": "../test-utils/tsconfig.build.json"


### PR DESCRIPTION
Test files were previously included in the `dist` folders which are published to NPM. I've added some exclusions to the `tsconfig.json`s to avoid this.