### PR TITLE
Add `clean` and `build:clean` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   ],
   "scripts": {
     "build": "tsc --build ./tsconfig.build.json",
+    "build:clean": "yarn clean && yarn build",
     "build:docs": "retype build",
+    "clean": "yarn build --clean",
     "get-typescript-versions": "./scripts/get-typescript-versions.sh",
     "postinstall": "simple-git-hooks",
     "lint": "yarn lint:eslint && yarn lint:constraints && yarn lint:misc --check && yarn lint:dependencies --check && yarn lint:changelogs",


### PR DESCRIPTION
This adds a `clean` script which cleans the output directories, and a `build:clean` script, which calls `clean` and `build`.