### PR TITLE
Release 15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   ],
   "scripts": {
     "build": "tsc --build ./tsconfig.build.json",
+    "build:clean": "yarn clean && yarn build",
     "build:docs": "retype build",
+    "clean": "yarn build --clean",
     "get-typescript-versions": "./scripts/get-typescript-versions.sh",
     "postinstall": "simple-git-hooks",
     "lint": "yarn lint:eslint && yarn lint:constraints && yarn lint:misc --check && yarn lint:dependencies --check && yarn lint:changelogs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/root",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "private": true,
   "description": "The root package of the monorepo.",
   "homepage": "https://github.com/ts-bridge/ts-bridge#readme",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Remove test files from dist ([#65](https://github.com/ts-bridge/ts-bridge/pull/65))
+- Add end-to-end tests ([#61](https://github.com/ts-bridge/ts-bridge/pull/61))
+- Remove custom files functionality ([#58](https://github.com/ts-bridge/ts-bridge/pull/58))
+- BREAKING: Add support for Node.js 22 and drop support for Node.js 21 ([#57](https://github.com/ts-bridge/ts-bridge/pull/57))
+- Build project references in parallel ([#56](https://github.com/ts-bridge/ts-bridge/pull/56))
+
 ## [0.5.1]
 
 ### Fixed

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,13 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0]
 
-### Uncategorized
+### Changed
 
-- Remove test files from dist ([#65](https://github.com/ts-bridge/ts-bridge/pull/65))
-- Add end-to-end tests ([#61](https://github.com/ts-bridge/ts-bridge/pull/61))
-- Remove custom files functionality ([#58](https://github.com/ts-bridge/ts-bridge/pull/58))
-- BREAKING: Add support for Node.js 22 and drop support for Node.js 21 ([#57](https://github.com/ts-bridge/ts-bridge/pull/57))
+- **BREAKING:** Add support for Node.js 22 and drop support for Node.js 21 ([#57](https://github.com/ts-bridge/ts-bridge/pull/57))
 - Build project references in parallel ([#56](https://github.com/ts-bridge/ts-bridge/pull/56))
+  - This change can significantly reduce the build time of projects with many
+    references.
 
 ## [0.5.1]
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0]
+
 ### Uncategorized
 
 - Remove test files from dist ([#65](https://github.com/ts-bridge/ts-bridge/pull/65))
@@ -151,7 +153,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/cli` package.
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.5.1...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.6.0...HEAD
+[0.6.0]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.5.1...@ts-bridge/cli@0.6.0
 [0.5.1]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.5.0...@ts-bridge/cli@0.5.1
 [0.5.0]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.4...@ts-bridge/cli@0.5.0
 [0.4.4]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.4.3...@ts-bridge/cli@0.4.4

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/cli",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Bridge the gap between ES modules and CommonJS modules with an easy-to-use alternative to `tsc`.",
   "keywords": [
     "build-tool",

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -9,10 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0]
 
-### Uncategorized
+### Changed
 
-- Remove test files from dist ([#65](https://github.com/ts-bridge/ts-bridge/pull/65))
-- BREAKING: Add support for Node.js 22 and drop support for Node.js 21 ([#57](https://github.com/ts-bridge/ts-bridge/pull/57))
+- **BREAKING:** Add support for Node.js 22 and drop support for Node.js 21 ([#57](https://github.com/ts-bridge/ts-bridge/pull/57))
 
 ## [0.1.2]
 

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0]
+
 ### Uncategorized
 
 - Remove test files from dist ([#65](https://github.com/ts-bridge/ts-bridge/pull/65))
@@ -31,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/resolver` package ([#20](https://github.com/ts-bridge/ts-bridge/pull/20), [#24](https://github.com/ts-bridge/ts-bridge/pull/24))
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.2...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.2.0...HEAD
+[0.2.0]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.2...@ts-bridge/resolver@0.2.0
 [0.1.2]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.1...@ts-bridge/resolver@0.1.2
 [0.1.1]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/resolver@0.1.0...@ts-bridge/resolver@0.1.1
 [0.1.0]: https://github.com/ts-bridge/ts-bridge/releases/tag/@ts-bridge/resolver@0.1.0

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Remove test files from dist ([#65](https://github.com/ts-bridge/ts-bridge/pull/65))
+- BREAKING: Add support for Node.js 22 and drop support for Node.js 21 ([#57](https://github.com/ts-bridge/ts-bridge/pull/57))
+
 ## [0.1.2]
 
 ### Fixed

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/resolver",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "An implementation of the Node.js module resolution algorithm.",
   "keywords": [
     "build-tool",


### PR DESCRIPTION
This is the release candidate for version `15.0.0`. The main changes are:

- Added support for Node.js 22, and dropped support for Node.js 21.
- Project references are now built in parallel (where possible).