### PR TITLE
fix: Properly handle reexports when detecting CJS exports

### DIFF
--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -168,7 +168,7 @@ export function getImports(
       const propertyName = element.propertyName?.text;
       const exportName = propertyName ?? name;
 
-      if (exports.includes(exportName)) {
+      if (exports.has(exportName)) {
         return {
           ...accumulator,
           detected: [...accumulator.detected, { name, propertyName }],

--- a/packages/cli/src/module-resolver.test.ts
+++ b/packages/cli/src/module-resolver.test.ts
@@ -355,22 +355,22 @@ describe('getFileSystemFromTypeScript', () => {
 
 describe('getCommonJsExports', () => {
   it('returns the exports for a CommonJS module', () => {
-    expect(getCommonJsExports('semver', sys, PARENT_URL)).toStrictEqual(
+    expect([...getCommonJsExports('semver', sys, PARENT_URL)]).toStrictEqual(
       expect.arrayContaining(['parse', 'valid', 'clean']),
     );
   });
 
-  it('returns an empty array if the module is not CommonJS', () => {
-    expect(getCommonJsExports('chalk', sys, PARENT_URL)).toStrictEqual([]);
+  it('returns an empty set if the module is not CommonJS', () => {
+    expect(getCommonJsExports('chalk', sys, PARENT_URL).size).toStrictEqual(0);
   });
 
-  it('returns an empty array if the module does not resolve', () => {
-    expect(getCommonJsExports('foo', sys, PARENT_URL)).toStrictEqual([]);
+  it('returns an empty set if the module does not resolve', () => {
+    expect(getCommonJsExports('foo', sys, PARENT_URL).size).toStrictEqual(0);
   });
 
-  it('returns an empty array if the code is empty', () => {
+  it('returns an empty set if the code is empty', () => {
     expect(
-      getCommonJsExports('commonjs-module/empty', sys, PARENT_URL),
-    ).toStrictEqual([]);
+      getCommonJsExports('commonjs-module/empty', sys, PARENT_URL).size,
+    ).toStrictEqual(0);
   });
 });

--- a/packages/cli/src/transformers.test.ts
+++ b/packages/cli/src/transformers.test.ts
@@ -1012,6 +1012,14 @@ describe('getNamedImportTransformer', () => {
       `);
     });
 
+    it('supports reexports', async () => {
+      expect(files['reexport.js']).toMatchInlineSnapshot(`
+        "import { baz } from 'reexport-module';
+        console.log(baz);
+        "
+      `);
+    });
+
     it('does not rewrite a named import for a detected CommonJS module import', async () => {
       expect(files['detected.js']).toMatchInlineSnapshot(`
         "import { foo } from 'commonjs-module';

--- a/packages/test-utils/test/fixtures/named-imports/package.json
+++ b/packages/test-utils/test/fixtures/named-imports/package.json
@@ -6,6 +6,7 @@
     "packages/*"
   ],
   "dependencies": {
-    "commonjs-module": "workspace:^"
+    "commonjs-module": "workspace:^",
+    "reexport-module": "workspace:^"
   }
 }

--- a/packages/test-utils/test/fixtures/named-imports/packages/reexport-module/baz.d.ts
+++ b/packages/test-utils/test/fixtures/named-imports/packages/reexport-module/baz.d.ts
@@ -1,0 +1,1 @@
+export declare const baz = 'baz';

--- a/packages/test-utils/test/fixtures/named-imports/packages/reexport-module/baz.js
+++ b/packages/test-utils/test/fixtures/named-imports/packages/reexport-module/baz.js
@@ -1,0 +1,1 @@
+module.exports.baz = 'baz';

--- a/packages/test-utils/test/fixtures/named-imports/packages/reexport-module/index.d.ts
+++ b/packages/test-utils/test/fixtures/named-imports/packages/reexport-module/index.d.ts
@@ -1,0 +1,1 @@
+export * from './baz';

--- a/packages/test-utils/test/fixtures/named-imports/packages/reexport-module/index.js
+++ b/packages/test-utils/test/fixtures/named-imports/packages/reexport-module/index.js
@@ -1,0 +1,19 @@
+'use strict';
+/* eslint-disable */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./baz"), exports);
+/* eslint-enable */

--- a/packages/test-utils/test/fixtures/named-imports/packages/reexport-module/package.json
+++ b/packages/test-utils/test/fixtures/named-imports/packages/reexport-module/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "reexport-module",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/packages/test-utils/test/fixtures/named-imports/src/reexport.ts
+++ b/packages/test-utils/test/fixtures/named-imports/src/reexport.ts
@@ -1,0 +1,3 @@
+import { baz } from 'reexport-module';
+
+console.log(baz);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,6 +1440,7 @@ __metadata:
   resolution: "@ts-bridge/named-imports-fixture@workspace:packages/test-utils/test/fixtures/named-imports"
   dependencies:
     commonjs-module: "workspace:^"
+    reexport-module: "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -4938,6 +4939,12 @@ __metadata:
   checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
   languageName: node
   linkType: hard
+
+"reexport-module@workspace:^, reexport-module@workspace:packages/test-utils/test/fixtures/named-imports/packages/reexport-module":
+  version: 0.0.0-use.local
+  resolution: "reexport-module@workspace:packages/test-utils/test/fixtures/named-imports/packages/reexport-module"
+  languageName: unknown
+  linkType: soft
 
 "regexpp@npm:^3.0.0":
   version: 3.2.0


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that
reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this
pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Fixes a bug where reexports were not properly traversed and therefore not included in the return value from `getImports`. This would cause issues with importing from packages that use the `__exportStar` pattern. For these packages `cjs-module-lexer` returns relative paths to the exports that must be traversed recursively to fully uncover the exports (at least this is what I gathered from https://github.com/nodejs/node/blob/3fb2ea8689250a3d39d9c66afd7301c7caa644c2/lib/internal/modules/esm/translators.js#L313-L346).

Sanity check welcome!
