### PR TITLE
Handle export detection errors

### DIFF
--- a/packages/cli/src/module-resolver.ts
+++ b/packages/cli/src/module-resolver.ts
@@ -333,6 +333,7 @@ export function isCommonJs(
  * @param system - The TypeScript system.
  * @param parentUrl - The URL of the parent module.
  * @returns The exports for the CommonJS package.
+ * @throws If the package could not be parsed.
  */
 export function getCommonJsExports(
   packageSpecifier: string,


### PR DESCRIPTION
Apparently `cjs-module-lexer` sometimes throws errors if a source file cannot be parsed. This was made apparent by React Native, which resolves to `react-native/index.js` which is a Flow file, instead of plain JavaScript.

To fix it, I've wrapped the export detection in a try-catch block, and if the source file cannot be parsed, we basically assume that the exports can be detected by whatever environment the code is running in.

Closes #72.