### PR TITLE
Remove implicit type imports and exports from output

### DIFF
--- a/packages/cli/src/generator.test.ts
+++ b/packages/cli/src/generator.test.ts
@@ -1,5 +1,10 @@
+import { assert } from '@metamask/utils';
 import { resolve } from '@ts-bridge/resolver';
-import { getFixture, getVirtualEnvironment } from '@ts-bridge/test-utils';
+import {
+  getFixture,
+  getMockTsConfig,
+  getVirtualEnvironment,
+} from '@ts-bridge/test-utils';
 import type {
   ExportDeclaration,
   ImportDeclaration,
@@ -519,6 +524,27 @@ describe('getNamedImportNodes', () => {
 });
 
 describe('getNonTypeImports', () => {
+  const { program, typeChecker, system } = getVirtualEnvironment({
+    files: {
+      '/index.ts': '// no-op',
+      '/foo.ts': `
+        export type Foo = number;
+        export const bar: string = 'bar';
+      `,
+      '/bar.ts': `
+        import { Foo, bar } from './foo';
+        export type Baz = Foo;
+        console.log(bar);
+      `,
+    },
+    tsconfig: getMockTsConfig({
+      compilerOptions: {
+        module: 'ESNext',
+        moduleResolution: 'ESNext',
+      },
+    }),
+  });
+
   it('removes type imports from an import declaration', () => {
     const importDeclaration = factory.createImportDeclaration(
       undefined,
@@ -542,13 +568,37 @@ describe('getNonTypeImports', () => {
       undefined,
     );
 
-    const result = getNonTypeImports(importDeclaration);
+    const result = getNonTypeImports(typeChecker, importDeclaration);
 
     expect(result).not.toBeUndefined();
     expect(result).not.toStrictEqual(importDeclaration);
     expect(compile(result as ImportDeclaration)).toMatchInlineSnapshot(`
       ""use strict";
       import { bar } from "foo";
+      "
+    `);
+  });
+
+  it('removes implicit type imports from an import declaration', () => {
+    // This test uses an actual source file, since the type checker is needed to
+    // detect the implicit type imports.
+    const sourceFile = program.getSourceFile('/bar.ts');
+    assert(sourceFile);
+
+    const importDeclaration = sourceFile.statements.find(
+      typescript.isImportDeclaration,
+    );
+
+    assert(importDeclaration);
+    const result = getNonTypeImports(typeChecker, importDeclaration);
+
+    expect(result).not.toBeUndefined();
+    expect(result).not.toStrictEqual(importDeclaration);
+
+    program.emit(undefined, undefined, undefined, false);
+    expect(system.readFile('/bar.js')).toMatchInlineSnapshot(`
+      "import { bar } from './foo';
+      console.log(bar);
       "
     `);
   });
@@ -565,7 +615,7 @@ describe('getNonTypeImports', () => {
       undefined,
     );
 
-    const result = getNonTypeImports(importDeclaration);
+    const result = getNonTypeImports(typeChecker, importDeclaration);
     expect(result).toBe(importDeclaration);
   });
 
@@ -577,7 +627,7 @@ describe('getNonTypeImports', () => {
       undefined,
     );
 
-    const result = getNonTypeImports(importDeclaration);
+    const result = getNonTypeImports(typeChecker, importDeclaration);
     expect(result).toBe(importDeclaration);
   });
 
@@ -604,12 +654,30 @@ describe('getNonTypeImports', () => {
       undefined,
     );
 
-    const result = getNonTypeImports(importDeclaration);
+    const result = getNonTypeImports(typeChecker, importDeclaration);
     expect(result).toBeUndefined();
   });
 });
 
 describe('getNonTypeExports', () => {
+  const { program, typeChecker, system } = getVirtualEnvironment({
+    files: {
+      '/index.ts': '// no-op',
+      '/foo.ts': `
+        type Foo = number;
+        const bar: string = 'bar';
+
+        export { Foo, bar };
+      `,
+    },
+    tsconfig: getMockTsConfig({
+      compilerOptions: {
+        module: 'ESNext',
+        moduleResolution: 'ESNext',
+      },
+    }),
+  });
+
   it('removes type exports from an export declaration', () => {
     const exportDeclaration = factory.createExportDeclaration(
       undefined,
@@ -628,12 +696,36 @@ describe('getNonTypeExports', () => {
       ]),
     );
 
-    const result = getNonTypeExports(exportDeclaration);
+    const result = getNonTypeExports(typeChecker, exportDeclaration);
 
     expect(result).not.toBeUndefined();
     expect(result).not.toStrictEqual(exportDeclaration);
     expect(compile(result as ExportDeclaration)).toMatchInlineSnapshot(`
       ""use strict";
+      export { bar };
+      "
+    `);
+  });
+
+  it('removes implicit type exports from an export declaration', () => {
+    // This test uses an actual source file, since the type checker is needed to
+    // detect the implicit type exports.
+    const sourceFile = program.getSourceFile('/foo.ts');
+    assert(sourceFile);
+
+    const exportDeclaration = sourceFile.statements.find(
+      typescript.isExportDeclaration,
+    );
+
+    assert(exportDeclaration);
+    const result = getNonTypeExports(typeChecker, exportDeclaration);
+
+    expect(result).not.toBeUndefined();
+    expect(result).not.toStrictEqual(exportDeclaration);
+
+    program.emit(undefined, undefined, undefined, false);
+    expect(system.readFile('/foo.js')).toMatchInlineSnapshot(`
+      "const bar = 'bar';
       export { bar };
       "
     `);
@@ -646,7 +738,7 @@ describe('getNonTypeExports', () => {
       factory.createNamespaceExport(factory.createIdentifier('foo')),
     );
 
-    const result = getNonTypeExports(exportDeclaration);
+    const result = getNonTypeExports(typeChecker, exportDeclaration);
     expect(result).toBe(exportDeclaration);
   });
 
@@ -657,7 +749,7 @@ describe('getNonTypeExports', () => {
       undefined,
     );
 
-    const result = getNonTypeExports(exportDeclaration);
+    const result = getNonTypeExports(typeChecker, exportDeclaration);
     expect(result).toBe(exportDeclaration);
   });
 
@@ -679,7 +771,7 @@ describe('getNonTypeExports', () => {
       ]),
     );
 
-    const result = getNonTypeExports(exportDeclaration);
+    const result = getNonTypeExports(typeChecker, exportDeclaration);
     expect(result).toBeUndefined();
   });
 });

--- a/packages/cli/src/transformers.ts
+++ b/packages/cli/src/transformers.ts
@@ -736,8 +736,8 @@ export function getNamedImportTransformer({
 
 /**
  * Get a transformer that removes type-only imports and exports. This is the
- * standard behaviour for TypeScript 5.x, but this transformer is needed for
- * TypeScript 4.x. This may be a bug in TypeScript 4.x's compiler API.
+ * default behaviour for TypeScript when invoked from the command line, but does
+ * not seem to be the default behaviour when using the TypeScript API.
  *
  * For example, the following type-only imports and exports:
  * ```ts
@@ -747,10 +747,13 @@ export function getNamedImportTransformer({
  *
  * will be removed.
  *
- * @param _context - The transformer options. This is not used.
+ * @param context - The transformer options.
+ * @param context.typeChecker - The type checker to use.
  * @returns The transformer function.
  */
-export function getTypeImportExportTransformer(_context: TransformerOptions) {
+export function getTypeImportExportTransformer({
+  typeChecker,
+}: TransformerOptions) {
   return (context: TransformationContext): Transformer<SourceFile> => {
     return (sourceFile: SourceFile) => {
       const visitor = (node: Node): Node | Node[] | undefined => {
@@ -759,7 +762,7 @@ export function getTypeImportExportTransformer(_context: TransformerOptions) {
             return undefined;
           }
 
-          return getNonTypeImports(node);
+          return getNonTypeImports(typeChecker, node);
         }
 
         if (isExportDeclaration(node)) {
@@ -767,7 +770,7 @@ export function getTypeImportExportTransformer(_context: TransformerOptions) {
             return undefined;
           }
 
-          return getNonTypeExports(node);
+          return getNonTypeExports(typeChecker, node);
         }
 
         return visitEachChild(node, visitor, context);


### PR DESCRIPTION
Types can be imported and exported explicitly, e.g., `import type { Foo } from './bar';`, but also implicitly, e.g., `import { Foo } from './bar';` (where `Foo` refers to a type, not a value). `ts-bridge` previously only removed explicit type imports and exports, by looking at the `isTypeOnly` value on the import/export declaration. `isTypeOnly` is not set for implicit type imports/exports however, meaning that they would end up in the final bundle if used.

For example:

```ts
// foo.ts
export type Foo = string;
export const foo: Foo = 'foo';

// bar.ts
import { Foo, foo } from './foo';

type Bar = Foo;
const bar = foo;
```

Before this change, `bar.mjs` would be:

```js
import { Foo, foo } from './foo.mjs';

const bar = foo;
```

`Foo` is still present in the import, even though it's not an actual JavaScript value, resulting in errors.

After this change, `Foo` is properly detected as being a type, and `bar.mjs` is outputted as:

```js
import { foo } from './foo.mjs';

const bar = foo;
```

Closes #76.