### PR TITLE
Keep default imports when removing type imports

### DIFF
--- a/packages/cli/src/generator.test.ts
+++ b/packages/cli/src/generator.test.ts
@@ -607,6 +607,40 @@ describe('getNonTypeImports', () => {
     `);
   });
 
+  it('removes named imports but not the default import', () => {
+    const importDeclaration = factory.createImportDeclaration(
+      undefined,
+      factory.createImportClause(
+        false,
+        factory.createIdentifier('foo'),
+        factory.createNamedImports([
+          factory.createImportSpecifier(
+            true,
+            undefined,
+            factory.createIdentifier('bar'),
+          ),
+          factory.createImportSpecifier(
+            true,
+            undefined,
+            factory.createIdentifier('baz'),
+          ),
+        ]),
+      ),
+      factory.createStringLiteral('baz'),
+      undefined,
+    );
+
+    const result = getNonTypeImports(typeChecker, importDeclaration);
+
+    expect(result).not.toBeUndefined();
+    expect(result).not.toStrictEqual(importDeclaration);
+    expect(compile(result as ImportDeclaration)).toMatchInlineSnapshot(`
+      ""use strict";
+      import foo from "baz";
+      "
+    `);
+  });
+
   it('returns the same node if the import declaration is not a named import', () => {
     const importDeclaration = factory.createImportDeclaration(
       undefined,

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -396,7 +396,7 @@ export function getNonTypeImports(
     isEmittable(typeChecker, element),
   );
 
-  if (elements.length === 0) {
+  if (!node.importClause.name && elements.length === 0) {
     return undefined;
   }
 
@@ -407,7 +407,9 @@ export function getNonTypeImports(
       node.importClause,
       false,
       node.importClause.name,
-      factory.updateNamedImports(node.importClause.namedBindings, elements),
+      elements.length === 0
+        ? undefined
+        : factory.updateNamedImports(node.importClause.namedBindings, elements),
     ),
     node.moduleSpecifier,
     node.attributes,


### PR DESCRIPTION
This fixes a bug where a default import would be removed if all named imports are type imports. For example, in the following case:

```
import foo, { type Bar, type Baz } from 'module';
```

the entire import statement would be removed. After this change, the default import is kept as-is and only the named imports are removed.

Closes #75.