### PR TITLE
fix: Validate `module` and `moduleResolution` in `tsconfig`

### DIFF
--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -129,6 +129,35 @@ describe('getTypeScriptConfig', () => {
       'Failed to parse the TypeScript configuration.',
     );
   });
+
+  it.each([
+    {
+      module: 'Node16',
+      moduleResolution: 'NodeNext',
+    },
+    { module: 'NodeNext', moduleResolution: 'Node16' },
+    { module: 'CommonJS', moduleResolution: 'Node16' },
+    { module: 'ESNext', moduleResolution: 'NodeNext' },
+    { module: 'Node16' },
+    { moduleResolution: 'NodeNext' },
+  ])(
+    'throws an error if the `module` and `moduleResolution` options do not match',
+    (compilerOptions) => {
+      const { system } = getVirtualEnvironment({
+        files: {
+          '/index.ts': '// no-op',
+        },
+        tsconfig: {
+          compilerOptions,
+        },
+        checkDiagnostic: false,
+      });
+
+      expect(() => getTypeScriptConfig('/tsconfig.json', system)).toThrowError(
+        'When using "Node16" or "NodeNext" module resolution, the "module" and "moduleResolution" compiler options must be the same.',
+      );
+    },
+  );
 });
 
 describe('getBaseCompilerOptions', () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from 'path';
-import type { CompilerOptions, System } from 'typescript';
+import type { CompilerOptions, ParsedCommandLine, System } from 'typescript';
 import typescript from 'typescript';
 
 import { TypeScriptError } from './errors.js';
@@ -43,6 +43,41 @@ function getTypeScriptConfigPath(path: string, system: System) {
 }
 
 /**
+ * Validate the TypeScript configuration. This checks for common
+ * misconfigurations and throws an error if any are found.
+ *
+ * @param config - The TypeScript configuration.
+ * @throws Will throw an error if the configuration is invalid.
+ */
+export function validateTypeScriptConfig(config: ParsedCommandLine) {
+  if (config.errors.length) {
+    throw new TypeScriptError(
+      'Failed to parse the TypeScript configuration.',
+      config.errors,
+    );
+  }
+
+  if (
+    (config.options.module === typescript.ModuleKind.Node16 &&
+      config.options.moduleResolution !==
+        typescript.ModuleResolutionKind.Node16) ||
+    (config.options.module === typescript.ModuleKind.NodeNext &&
+      config.options.moduleResolution !==
+        typescript.ModuleResolutionKind.NodeNext) ||
+    (config.options.moduleResolution ===
+      typescript.ModuleResolutionKind.Node16 &&
+      config.options.module !== typescript.ModuleKind.Node16) ||
+    (config.options.moduleResolution ===
+      typescript.ModuleResolutionKind.NodeNext &&
+      config.options.module !== typescript.ModuleKind.NodeNext)
+  ) {
+    throw new Error(
+      `When using "Node16" or "NodeNext" module resolution, the "module" and "moduleResolution" compiler options must be the same.`,
+    );
+  }
+}
+
+/**
  * Get the TypeScript configuration.
  *
  * This function reads the TypeScript configuration from the specified path.
@@ -73,12 +108,7 @@ export function getTypeScriptConfig(path: string, system = sys) {
     resolvedPath,
   );
 
-  if (parsedConfig.errors.length) {
-    throw new TypeScriptError(
-      'Failed to parse the TypeScript configuration.',
-      parsedConfig.errors,
-    );
-  }
+  validateTypeScriptConfig(parsedConfig);
 
   return parsedConfig;
 }


### PR DESCRIPTION
This adds some additional validation of the `tsconfig.json`, since TypeScript seemingly doesn't always catch these cases. This should prevent cases like in #83, where the `.mjs` files were generated containing CJS code, resulting in a broken build (though `ts-bridge` wasn't throwing any errors).

Closes #83.