### PR TITLE
release: `19.0.0`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - id: is-release
         uses: MetaMask/action-is-release@v2
         with:
-          commit-starts-with: 'Release [version],Release/[version]'
+          commit-starts-with: 'Release [version],Release `[version]`,release: [version],release: `[version]`'
 
   publish-release:
     name: Publish release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/root",
-  "version": "18.0.0",
+  "version": "19.0.0",
   "private": true,
   "description": "The root package of the monorepo.",
   "homepage": "https://github.com/ts-bridge/ts-bridge#readme",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.4]
 
-### Uncategorized
+### Fixed
 
-- fix: Validate `module` and `moduleResolution` in `tsconfig` ([#84](https://github.com/ts-bridge/ts-bridge/pull/84))
-- fix: Add error hint to project references error ([#85](https://github.com/ts-bridge/ts-bridge/pull/85))
-- chore(dev-deps): Bump `@types/node` from `^20.12.7` to `^22.9.0` ([#86](https://github.com/ts-bridge/ts-bridge/pull/86))
+- Validate `module` and `moduleResolution` in `tsconfig` ([#84](https://github.com/ts-bridge/ts-bridge/pull/84))
+  - This prevents misconfiguration that could lead to incorrect behavior when
+    building the project.
+- Add error hint to project references error ([#85](https://github.com/ts-bridge/ts-bridge/pull/85))
 
 ## [0.6.3]
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4]
+
 ### Uncategorized
 
 - fix: Validate `module` and `moduleResolution` in `tsconfig` ([#84](https://github.com/ts-bridge/ts-bridge/pull/84))
@@ -182,7 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `@ts-bridge/cli` package.
 
-[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.6.3...HEAD
+[Unreleased]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.6.4...HEAD
+[0.6.4]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.6.3...@ts-bridge/cli@0.6.4
 [0.6.3]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.6.2...@ts-bridge/cli@0.6.3
 [0.6.2]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.6.1...@ts-bridge/cli@0.6.2
 [0.6.1]: https://github.com/ts-bridge/ts-bridge/compare/@ts-bridge/cli@0.6.0...@ts-bridge/cli@0.6.1

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: Validate `module` and `moduleResolution` in `tsconfig` ([#84](https://github.com/ts-bridge/ts-bridge/pull/84))
+- fix: Add error hint to project references error ([#85](https://github.com/ts-bridge/ts-bridge/pull/85))
+- chore(dev-deps): Bump `@types/node` from `^20.12.7` to `^22.9.0` ([#86](https://github.com/ts-bridge/ts-bridge/pull/86))
+
 ## [0.6.3]
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-bridge/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Bridge the gap between ES modules and CommonJS modules with an easy-to-use alternative to `tsc`.",
   "keywords": [
     "build-tool",


### PR DESCRIPTION
This is the release candidate for version `19.0.0`, which contains a patch release of `@ts-bridge/cli`.